### PR TITLE
feat, refactor: 채팅 기능 구현 및 코드 리팩토링

### DIFF
--- a/livestudy/build.gradle
+++ b/livestudy/build.gradle
@@ -49,8 +49,6 @@ dependencies {
     // LiveKit
     implementation 'io.livekit:livekit-server:0.10.0'
 
-
-
     // MySQL, H2 DB
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/livestudy/src/main/java/org/livestudy/repository/ChatRepository.java
+++ b/livestudy/src/main/java/org/livestudy/repository/ChatRepository.java
@@ -1,0 +1,10 @@
+package org.livestudy.repository;
+
+import org.livestudy.domain.studyroom.Chat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+}

--- a/livestudy/src/main/java/org/livestudy/repository/StudyRoomParticipantRepository.java
+++ b/livestudy/src/main/java/org/livestudy/repository/StudyRoomParticipantRepository.java
@@ -1,8 +1,13 @@
 package org.livestudy.repository;
 
-import org.livestudy.domain.studyroom.Chat;
+import org.livestudy.domain.studyroom.StudyRoom;
 import org.livestudy.domain.studyroom.StudyRoomParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StudyRoomParticipantRepository extends JpaRepository<StudyRoomParticipant, Long> {
+
+    Optional<StudyRoomParticipant> findByStudyRoomAndUserId(StudyRoom studyRoom, Long userId);
+
 }

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtTokenProvider.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtTokenProvider.java
@@ -67,7 +67,7 @@ public class JwtTokenProvider {
     }
 
     // token 검증
-    public boolean validateToken(String token){
+    public boolean validateToken(String token) {
         try {
             SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
 
@@ -86,8 +86,8 @@ public class JwtTokenProvider {
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
     }
-
 
     // Claims 내용 반환
     private Claims parseClaims(String token) {
@@ -102,22 +102,17 @@ public class JwtTokenProvider {
 
     // Token으로 이메일 가져오기
     public String getEmailFromToken(String token) {
-        Jwt<?, ?> jwt = Jwts
-                .parser()
-                .verifyWith(key)
-                .build()
-                .parse(token);
 
-        return ((Claims) jwt.getPayload()).getSubject();  // getBody() → getPayload()
+        return parseClaims(token).getSubject();
     }
     // 토큰 만료 여부 체크
-    private boolean isTokenExpired(Claims claims) {
-        return claims.getExpiration().before(new Date());
-      
+    private boolean isTokenExpired(Claims claims){
+            return claims.getExpiration().before(new Date());
+        }
+
     // 사용자 고유 식별자(ID)를 추출하기 위한 Method
-    public String getUserId(String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build()
-                .parseClaimsJws(token).getBody().getSubject();
+    public Long getUserIdFromToken(String token) {
+        return parseClaims(token).get("userId", Long.class);
 
     }
 }

--- a/livestudy/src/main/java/org/livestudy/service/ChatService.java
+++ b/livestudy/src/main/java/org/livestudy/service/ChatService.java
@@ -1,6 +1,7 @@
 package org.livestudy.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.livestudy.domain.studyroom.Chat;
 import org.livestudy.domain.studyroom.StudyRoom;
 import org.livestudy.domain.studyroom.StudyRoomParticipant;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ChatService {
 
@@ -26,12 +28,17 @@ public class ChatService {
     public void saveChat(String roomId, String senderId, String message) {
         Long longRoomId = Long.parseLong(roomId);
         StudyRoom studyRoom = studyRoomRepo.findById(longRoomId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
-
+                .orElseGet(() -> {
+                    log.error(" {} 번의 스터디룸을 찾을 수 없습니다.", longRoomId);
+                    throw new CustomException(ErrorCode.ROOM_NOT_FOUND);
+                });
         Long longSenderId = Long.parseLong(senderId);
         StudyRoomParticipant participant = studyRoomParticipantRepo
                 .findByStudyRoomAndUserId(studyRoom, longSenderId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_IN_ROOM));
+                .orElseGet(() -> {
+                    log.error(" {} 유저가 해당 {} 스터디룸에 존재하지 않습니다.", longSenderId, longRoomId);
+                    throw new CustomException(ErrorCode.USER_NOT_IN_ROOM);
+                });
 
         Chat chat = Chat.builder()
                 .studyRoom(studyRoom)

--- a/livestudy/src/main/java/org/livestudy/service/ChatService.java
+++ b/livestudy/src/main/java/org/livestudy/service/ChatService.java
@@ -1,0 +1,45 @@
+package org.livestudy.service;
+
+import lombok.RequiredArgsConstructor;
+import org.livestudy.domain.studyroom.Chat;
+import org.livestudy.domain.studyroom.StudyRoom;
+import org.livestudy.domain.studyroom.StudyRoomParticipant;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.ChatRepository;
+import org.livestudy.repository.StudyRoomParticipantRepository;
+import org.livestudy.repository.StudyRoomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRepository chatRepo;
+    private final StudyRoomRepository studyRoomRepo;
+    private final StudyRoomParticipantRepository studyRoomParticipantRepo;
+
+    @Transactional
+    public void saveChat(String roomId, String senderId, String message) {
+        Long longRoomId = Long.parseLong(roomId);
+        StudyRoom studyRoom = studyRoomRepo.findById(longRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+        Long longSenderId = Long.parseLong(senderId);
+        StudyRoomParticipant participant = studyRoomParticipantRepo
+                .findByStudyRoomAndUserId(studyRoom, longSenderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_IN_ROOM));
+
+        Chat chat = Chat.builder()
+                .studyRoom(studyRoom)
+                .participant(participant)
+                .message(message)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        chatRepo.save(chat);
+    }
+}

--- a/livestudy/src/main/java/org/livestudy/service/report/RedisSubscriber.java
+++ b/livestudy/src/main/java/org/livestudy/service/report/RedisSubscriber.java
@@ -21,7 +21,7 @@ public class RedisSubscriber implements MessageListener {
 
         log.info("{} 채널로부터 {} 메시지를 받았습니다", channel, message);
 
-        if(channel.startsWith("restriction:")) {
+        if (channel.startsWith("restriction:")) {
             handleRestrictionMessage(channel, msg);
         } else if (channel.startsWith("systemMessage:")) {
             handleSystemMessage(channel, msg);

--- a/livestudy/src/main/java/org/livestudy/websocket/controller/RoomWebSocketController.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/controller/RoomWebSocketController.java
@@ -1,6 +1,7 @@
 package org.livestudy.websocket.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.livestudy.exception.CustomException;
 import org.livestudy.exception.ErrorCode;
 import org.livestudy.service.ChatService;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Controller;
 
 import java.time.Instant;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class RoomWebSocketController {
@@ -72,11 +74,13 @@ public class RoomWebSocketController {
         ChatPayload chat = msg.getPayload();
 
         // 유효성 검사
-        if (!sessionUser.equals(chat.getUserId())) {
+        if (sessionUser == null || !sessionUser.equals(chat.getUserId())) {
+            log.error("유저 ID 불일치. 세션 userId: {}, 페이로드 userId: {}", sessionUser, chat.getUserId());
             throw new CustomException(ErrorCode.USER_ID_MISMATCH);
         }
-
         if (roomId == null || !roomId.equals(chat.getRoomId())) {
+            log.error("유저가 방에 존재하지 않습니다. 세션 roomId: {}, 페이로드 roomId: {}, userId: {}",
+                    roomId, chat.getRoomId(), sessionUser);
             throw new CustomException(ErrorCode.USER_NOT_IN_ROOM);
         }
 

--- a/livestudy/src/test/java/org/livestudy/service/ChatServiceTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/ChatServiceTest.java
@@ -1,0 +1,132 @@
+package org.livestudy.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.livestudy.domain.studyroom.*;
+import org.livestudy.domain.user.User;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.ChatRepository;
+import org.livestudy.repository.StudyRoomParticipantRepository;
+import org.livestudy.repository.StudyRoomRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceUnitTest {
+
+    @Mock
+    private ChatRepository chatRepo;
+    @Mock
+    private StudyRoomRepository studyRoomRepo;
+    @Mock
+    private StudyRoomParticipantRepository studyRoomParticipantRepo;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    private StudyRoom testStudyRoom;
+    private StudyRoomParticipant testParticipant;
+    private User testUser;
+
+    private final Long testRoomId = 1L;
+    private final Long testSenderId = 10L;
+    private final String testMessageContent = "안녕하세요.";
+
+    @BeforeEach // 각 테스트 메서드가 실행되기 전에 호출
+    void setUp() {
+
+        testUser = mock(User.class);
+
+        testStudyRoom = StudyRoom.builder()
+                .id(1L)
+                .participantsNumber(5)
+                .status(StudyRoomStatus.OPEN)
+                .build();
+
+        testParticipant = StudyRoomParticipant.builder()
+                .id(10L)
+                .user(testUser)
+                .studyRoom(testStudyRoom)
+                .joinTime(LocalDateTime.now())
+                .focusStatus(FocusStatus.FOCUS)
+                .build();
+    }
+
+    @Test
+    @DisplayName("채팅 메시지 저장 성공")
+    void saveChat_Success() {
+        // given
+        // studyRoomRepo.findById(1L) 호출 시 testStudyRoom 반환하도록 Mocking
+        when(studyRoomRepo.findById(testRoomId))
+                .thenReturn(Optional.of(testStudyRoom));
+        // studyRoomParticipantRepo.findByStudyRoomAndUserId(testStudyRoom, testSenderId) 호출 시 testParticipant 반환하도록 Mocking
+        when(studyRoomParticipantRepo.findByStudyRoomAndUserId(eq(testStudyRoom), eq(testSenderId)))
+                .thenReturn(Optional.of(testParticipant));
+        // chatRepo.save(any(Chat.class)) 호출 시 any(Chat.class) 객체 그대로 반환하도록 Mocking
+        when(chatRepo.save(any(Chat.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        chatService.saveChat(testRoomId.toString(), testSenderId.toString(), testMessageContent);
+
+        // then
+        // save 메서드가 1번 호출되었는지 검증
+        verify(chatRepo, times(1)).save(any(Chat.class));
+        // studyRoomRepo.findById와 studyRoomParticipantRepo.findByStudyRoomAndUserId가 각각 1번씩 호출되었는지 검증
+        verify(studyRoomRepo, times(1)).findById(testRoomId);
+        verify(studyRoomParticipantRepo, times(1)).findByStudyRoomAndUserId(eq(testStudyRoom), eq(testSenderId));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 방 ID로 채팅 메시지 저장 시 예외 발생")
+    void saveChat_RoomNotFound() {
+        // given
+        // studyRoomRepo.findById 호출 시 빈 Optional 반환하도록 Mocking
+        when(studyRoomRepo.findById(testRoomId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                chatService.saveChat(testRoomId.toString(), testSenderId.toString(), testMessageContent)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+
+        // chatRepo.save는 호출되지 않았음을 검증
+        verify(chatRepo, never()).save(any(Chat.class));
+        verify(studyRoomParticipantRepo, never()).findByStudyRoomAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("방에 없는 사용자 ID로 채팅 메시지 저장 시 예외 발생")
+    void saveChat_UserNotInRoom() {
+        // given
+        // studyRoomRepo.findById 호출 시 testStudyRoom 반환하도록 Mocking
+        when(studyRoomRepo.findById(testRoomId))
+                .thenReturn(Optional.of(testStudyRoom));
+        // studyRoomParticipantRepo.findByStudyRoomAndUserId 호출 시 빈 Optional 반환하도록 Mocking
+        when(studyRoomParticipantRepo.findByStudyRoomAndUserId(eq(testStudyRoom), eq(testSenderId)))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                chatService.saveChat(testRoomId.toString(), testSenderId.toString(), testMessageContent)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_IN_ROOM);
+
+        // chatRepo.save는 호출되지 않았음을 검증
+        verify(chatRepo, never()).save(any(Chat.class));
+        verify(studyRoomRepo, times(1)).findById(testRoomId); // StudyRoom은 찾았지만 Participant를 못 찾음
+    }
+}


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 공부방 내의 채팅 기능을 구현합니다.
 1. 유저는 같은 공부방에 참여한 유저들과 실시간으로 채팅을 주고 받을 수 있습니다.
 2. 공부방의 특성 상, 새로운 유저가 들어왔을 때 기존에 있는 채팅방의 내용은 확인할 수 없습니다.
 3. 모든 채팅은 DB(mysql)에 저장합니다.

# 변경된 사항
 1. 채팅 기능 구현
    - ChatService.java: 채팅 기록을 DB에 저장
    - RoomWebSocketController의 chat 메서드: 유효성 검사 및 클라이언트에게 받은 메시지를 브로드캐스트
 2. JwtHandshakeInterceptor의 beforeHandshake 코드 간결화
 3. JwtTokenProvider의 오류 수정 및 코드 간결화

# 테스트
 1. 단위 테스트(ChatServiceTest.java): 채팅을 정상적으로 저장하고, 예외 상황을 올바르게 처리하는지 테스트