### PR TITLE
feat: 사용자 통계 기능 구현

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
@@ -1,0 +1,33 @@
+package org.livestudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.livestudy.dto.UserStudyStatsResponse;
+import org.livestudy.security.SecurityUser;
+import org.livestudy.service.UserStudyStatService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/profile")
+public class UserProfileController {
+
+    private final UserStudyStatService userStudyStatService;
+
+    // 누적 공부시간
+    @GetMapping
+    public ResponseEntity<UserStudyStatsResponse> getTotalStudyTime(
+            @AuthenticationPrincipal SecurityUser user) {
+
+        Long userId = user.getUser().getId();
+        log.info("마이페이지 - userId: {} 유저의 총 공부시간", userId);
+        UserStudyStatsResponse statsResponse = userStudyStatService
+                .getUserStudyStats(userId);
+
+        return ResponseEntity.ok(statsResponse);
+    }
+
+}

--- a/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
@@ -2,6 +2,7 @@ package org.livestudy.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.livestudy.dto.AverageFocusRatioResponse;
 import org.livestudy.dto.DailyRecordResponse;
 import org.livestudy.dto.UserStudyStatsResponse;
 import org.livestudy.security.SecurityUser;
@@ -58,7 +59,7 @@ public class UserStatController {
     }
 
     @GetMapping("/average-focus-ratio")
-    public ResponseEntity<Double> getAverageFocusRatio(
+    public ResponseEntity<AverageFocusRatioResponse> getAverageFocusRatio(
             @AuthenticationPrincipal SecurityUser user,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
@@ -71,7 +72,8 @@ public class UserStatController {
         log.info("통계 페이지 - userId: {} 유저의 기간별 집중률 조회", userId);
         Double averageFocusRatio = userStudyStatService.getAverageStudyRatio(userId, start, end);
 
-        return ResponseEntity.ok(averageFocusRatio);
+        AverageFocusRatioResponse response = new AverageFocusRatioResponse(start, end, averageFocusRatio);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
@@ -1,0 +1,77 @@
+package org.livestudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.livestudy.dto.DailyRecordResponse;
+import org.livestudy.dto.UserStudyStatsResponse;
+import org.livestudy.security.SecurityUser;
+import org.livestudy.service.UserStudyStatService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/stat")
+public class UserStatController {
+
+    private final UserStudyStatService userStudyStatService;
+
+    // 기본 데이터
+    @GetMapping("/normal")
+    public ResponseEntity<UserStudyStatsResponse> getUserNormalStats(
+            @AuthenticationPrincipal SecurityUser user) {
+
+        Long userId = user.getUser().getId();
+
+        log.info("통계 페이지 - userId: {} 유저의 공부 정보 조회", userId);
+        UserStudyStatsResponse statsResponse = userStudyStatService
+                .getUserStudyStats(userId);
+
+        return ResponseEntity.ok(statsResponse);
+    }
+
+    @GetMapping("/daily-focus")
+    public ResponseEntity<List<DailyRecordResponse>> getDailyFocus(
+            @AuthenticationPrincipal SecurityUser user,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        Long userId = user.getUser().getId();
+
+        LocalDate end = (endDate != null) ? endDate : LocalDate.now();
+        LocalDate start = (startDate != null) ? startDate : LocalDate.now().minusDays(6);
+
+        log.info("통계 페이지 - userId: {} 유저의 일별 집중도 추이 조회", userId);
+        List<DailyRecordResponse> dailyFocus = userStudyStatService.getDailyRecord(
+                userId, start, end);
+
+        return ResponseEntity.ok(dailyFocus);
+    }
+
+    @GetMapping("/average-focus-ratio")
+    public ResponseEntity<Double> getAverageFocusRatio(
+            @AuthenticationPrincipal SecurityUser user,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        Long userId = user.getUser().getId();
+
+        LocalDate end = (endDate != null) ? endDate : LocalDate.now();
+        LocalDate start = (startDate != null) ? startDate : LocalDate.now().minusDays(6);
+
+        log.info("통계 페이지 - userId: {} 유저의 기간별 집중률 조회", userId);
+        Double averageFocusRatio = userStudyStatService.getAverageStudyRatio(userId, start, end);
+
+        return ResponseEntity.ok(averageFocusRatio);
+    }
+
+}

--- a/livestudy/src/main/java/org/livestudy/domain/user/DailyStudyRecord.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/DailyStudyRecord.java
@@ -1,0 +1,44 @@
+package org.livestudy.domain.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "daily_study_records")
+public class DailyStudyRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long    id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "record_date", nullable = false)
+    private LocalDate recordDate;
+
+    @Builder.Default
+    @Column(name = "daily_study_time", nullable = false)
+    private Integer dailyStudyTime = 0;
+
+    @Builder.Default
+    @Column(name = "daily_away_time", nullable = false)
+    private Integer dailyAwayTime = 0;
+
+    // 집중률
+    @Transient
+    public Double getFocusRatio() {
+        if (dailyStudyTime + dailyAwayTime == 0) {
+            return 0.0;
+        }
+        return (double) dailyStudyTime / (dailyStudyTime + dailyAwayTime) * 100;
+    }
+}

--- a/livestudy/src/main/java/org/livestudy/domain/user/UserStudyStat.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/UserStudyStat.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/livestudy/src/main/java/org/livestudy/dto/AverageFocusRatioResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/AverageFocusRatioResponse.java
@@ -1,0 +1,18 @@
+package org.livestudy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AverageFocusRatioResponse {
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Double averageFocusRatio;
+}

--- a/livestudy/src/main/java/org/livestudy/dto/DailyRecordResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/DailyRecordResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Builder
 public class DailyRecordResponse {
     private LocalDate recordDate;
-    private int dailyStudyTime;
-    private int dailyAwayTime;
-    private double focusRatio;
+    private Long dailyStudyTime;
+    private Long dailyAwayTime;
+    private Double focusRatio;
 }

--- a/livestudy/src/main/java/org/livestudy/dto/DailyRecordResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/DailyRecordResponse.java
@@ -1,0 +1,15 @@
+package org.livestudy.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DailyRecordResponse {
+    private LocalDate recordDate;
+    private int dailyStudyTime;
+    private int dailyAwayTime;
+    private double focusRatio;
+}

--- a/livestudy/src/main/java/org/livestudy/dto/UserStudyStatsResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserStudyStatsResponse.java
@@ -1,0 +1,35 @@
+package org.livestudy.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.livestudy.domain.user.UserStudyStat;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UserStudyStatsResponse {
+
+    private Long userId;
+    private String nickname;
+    private Integer totalStudyTime;
+    private Integer totalAwayTime;
+    private Integer totalAttendanceDays;
+    private Integer continueAttendanceDays;
+    private LocalDate lastAttendanceDate;
+
+    public static UserStudyStatsResponse from(UserStudyStat userStudyStat) {
+
+        return UserStudyStatsResponse.builder()
+                .userId(userStudyStat.getUser().getId())
+                .nickname(userStudyStat.getUser().getNickname())
+                .totalStudyTime(userStudyStat.getTotalStudyTime())
+                .totalAwayTime(userStudyStat.getTotalAwayTime())
+                .totalAttendanceDays(userStudyStat.getTotalAttendanceDays())
+                .continueAttendanceDays(userStudyStat.getContinueAttendanceDays())
+                .lastAttendanceDate(userStudyStat.getLastAttendanceDate())
+                .build();
+    }
+
+
+}

--- a/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
+++ b/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
     INVALID_INPUT("C002", "잘못된 입력 값입니다.", HttpStatus.BAD_REQUEST),
 
     // 유저 관련 에러
-    USER_NOT_FOUND("U001", "존재하지 않는 사용자입니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("U001", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_EMAIL("U002", "이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
     INVALID_PASSWORD("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     ROOM_NOT_FOUND("U004", "존재하지 않는 방입니다.", HttpStatus.NOT_FOUND),
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_ROOM_CAPACITY("U007", "방의 정원이 알맞지 않습니다.", HttpStatus.BAD_REQUEST),
     ROOM_IS_FULL("U008", "방이 이미 가득 찼습니다.", HttpStatus.BAD_REQUEST),
     USER_NOT_IN_ROOM("U009", "사용자가 방에 없습니다.", HttpStatus.BAD_REQUEST),
+    STAT_NOT_FOUND("U010", "사용자의 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER_BLOCKED("U010", "정지된 사용자입니다.", HttpStatus.FORBIDDEN),
     USER_WITHDRAW("U011", "탈퇴한 사용자입니다.", HttpStatus.FORBIDDEN),
 
@@ -81,4 +82,6 @@ public enum ErrorCode {
         this.message = message;
         this.httpStatus = httpStatus;
     }
+
+
 }

--- a/livestudy/src/main/java/org/livestudy/repository/DailyStudyRecordRepository.java
+++ b/livestudy/src/main/java/org/livestudy/repository/DailyStudyRecordRepository.java
@@ -1,0 +1,20 @@
+package org.livestudy.repository;
+
+import org.livestudy.domain.user.DailyStudyRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DailyStudyRecordRepository extends JpaRepository<DailyStudyRecord, Long> {
+
+    Optional<DailyStudyRecord> findByUserIdAndRecordDate (Long userId, LocalDate recordDate);
+
+    // 특정 기간의 DailyStudyRecord 조회(날짜 순)
+    List<DailyStudyRecord> findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+            Long userId, LocalDate startDate, LocalDate endDate);
+
+}

--- a/livestudy/src/main/java/org/livestudy/repository/UserStudyStatRepository.java
+++ b/livestudy/src/main/java/org/livestudy/repository/UserStudyStatRepository.java
@@ -1,0 +1,13 @@
+package org.livestudy.repository;
+
+import org.livestudy.domain.user.UserStudyStat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserStudyStatRepository extends JpaRepository<UserStudyStat, Long> {
+
+    Optional<UserStudyStat> findByUserId(Long userId);
+}

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtTokenProvider.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtTokenProvider.java
@@ -27,9 +27,8 @@ public class JwtTokenProvider {
 
     private final long tokenValidTime = 60 * 60 * 1000;
 
-
     @PostConstruct
-    protected void init(){
+    public void init(){
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         this.jwtParser = Jwts.parser().verifyWith((SecretKey) key).build();
     }
@@ -88,7 +87,7 @@ public class JwtTokenProvider {
     }
 
     // 사용자 ID 추출
-    public Long getUserId(String token) {
+    public Long getUserIdFromToken(String token) {
         return parseClaims(token).get("userId", Long.class);
     }
 

--- a/livestudy/src/main/java/org/livestudy/service/TimerServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/TimerServiceImpl.java
@@ -4,16 +4,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.livestudy.domain.studyroom.FocusStatus;
 import org.livestudy.domain.studyroom.StudyRoomParticipant;
+import org.livestudy.domain.user.DailyStudyRecord;
+import org.livestudy.domain.user.User;
+import org.livestudy.domain.user.UserStudyStat;
 import org.livestudy.dto.timer.TimerResponse;
 import org.livestudy.dto.timer.TimerStatusResponse;
 import org.livestudy.exception.CustomException;
 import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.DailyStudyRecordRepository;
 import org.livestudy.repository.StudyRoomParticipantRepository;
+import org.livestudy.repository.UserStudyStatRepository;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -23,8 +29,10 @@ import java.util.Map;
 @Transactional
 public class TimerServiceImpl implements TimerService {
 
-    private final StudyRoomParticipantRepository participantRepository;
+    private final StudyRoomParticipantRepository participantRepo;
     private final SimpMessagingTemplate messagingTemplate;
+    private final UserStudyStatRepository userStudyStatRepo;
+    private final DailyStudyRecordRepository dailyStudyRecordRepo;
 
     @Override
     public TimerResponse startFocus(Long userId, Long roomId) {
@@ -32,18 +40,25 @@ public class TimerServiceImpl implements TimerService {
 
         StudyRoomParticipant participant = findActiveParticipant(userId, roomId);
         LocalDateTime now = LocalDateTime.now();
+        int awayTime = 0;
 
         // 현재 상태가 자리비움이었다면 자리비움 시간을 누적
         if (participant.getFocusStatus() == FocusStatus.AWAY && participant.getStatusChangedAt() != null) {
             int awayDuration = (int) Duration.between(participant.getStatusChangedAt(), now).getSeconds();
             participant = updateParticipant(participant, FocusStatus.FOCUS, now,
                     participant.getStudyTime(), participant.getAwayTime() + awayDuration);
+            awayTime = awayDuration;
         } else {
             participant = updateParticipant(participant, FocusStatus.FOCUS, now,
                     participant.getStudyTime(), participant.getAwayTime());
         }
 
-        StudyRoomParticipant saved = participantRepository.save(participant);
+        StudyRoomParticipant saved = participantRepo.save(participant);
+
+        // 유저의 공부 정보에 업데이트
+        if (awayTime > 0) {
+            updateStudyStatsAndDailyRecord(saved.getUser(), 0, awayTime);
+        }
 
         // WebSocket으로 상태 변경 알림
         broadcastTimerUpdate(roomId, userId, "FOCUS_START", saved);
@@ -57,18 +72,25 @@ public class TimerServiceImpl implements TimerService {
 
         StudyRoomParticipant participant = findActiveParticipant(userId, roomId);
         LocalDateTime now = LocalDateTime.now();
+        int studyTime = 0;
 
         // 현재 상태가 집중이었다면 집중 시간을 누적
         if (participant.getFocusStatus() == FocusStatus.FOCUS && participant.getStatusChangedAt() != null) {
             int studyDuration = (int) Duration.between(participant.getStatusChangedAt(), now).getSeconds();
             participant = updateParticipant(participant, FocusStatus.AWAY, now,
                     participant.getStudyTime() + studyDuration, participant.getAwayTime());
+            studyTime = studyDuration;
         } else {
             participant = updateParticipant(participant, FocusStatus.AWAY, now,
                     participant.getStudyTime(), participant.getAwayTime());
         }
 
-        StudyRoomParticipant saved = participantRepository.save(participant);
+        StudyRoomParticipant saved = participantRepo.save(participant);
+
+        // 유저의 공부 정보에 업데이트
+        if (studyTime > 0) {
+            updateStudyStatsAndDailyRecord(saved.getUser(), studyTime, 0);
+        }
 
         // WebSocket으로 상태 변경 알림
         broadcastTimerUpdate(roomId, userId, "FOCUS_PAUSE", saved);
@@ -88,6 +110,8 @@ public class TimerServiceImpl implements TimerService {
 
         StudyRoomParticipant participant = findActiveParticipant(userId, roomId);
         LocalDateTime now = LocalDateTime.now();
+        int studyTime = 0;
+        int awayTime = 0;
 
         // 현재 진행 중인 시간을 마지막으로 누적
         if (participant.getStatusChangedAt() != null) {
@@ -96,9 +120,11 @@ public class TimerServiceImpl implements TimerService {
             if (participant.getFocusStatus() == FocusStatus.FOCUS) {
                 participant = updateParticipant(participant, FocusStatus.AWAY, now,
                         participant.getStudyTime() + duration, participant.getAwayTime());
+                studyTime = duration;
             } else {
                 participant = updateParticipant(participant, FocusStatus.AWAY, now,
                         participant.getStudyTime(), participant.getAwayTime() + duration);
+                awayTime = duration;
             }
         }
 
@@ -115,7 +141,12 @@ public class TimerServiceImpl implements TimerService {
                 .awayTime(participant.getAwayTime())
                 .build();
 
-        StudyRoomParticipant saved = participantRepository.save(participant);
+        StudyRoomParticipant saved = participantRepo.save(participant);
+
+        // 유저의 공부 정보에 업데이트
+        if (studyTime > 0 || awayTime > 0) {
+            updateStudyStatsAndDailyRecord(saved.getUser(), studyTime, awayTime);
+        }
 
         // WebSocket으로 종료 알림
         broadcastTimerUpdate(roomId, userId, "FOCUS_STOP", saved);
@@ -162,7 +193,7 @@ public class TimerServiceImpl implements TimerService {
     // === Private Helper Methods ===
 
     private StudyRoomParticipant findActiveParticipant(Long userId, Long roomId) {
-        return participantRepository.findByUserIdAndStudyRoomIdAndLeaveTimeIsNull(userId, roomId)
+        return participantRepo.findByUserIdAndStudyRoomIdAndLeaveTimeIsNull(userId, roomId)
                 .orElseThrow(() -> {
                     log.error("활성 참여자를 찾을 수 없음: userId={}, roomId={}", userId, roomId);
                     return new CustomException(ErrorCode.USER_NOT_FOUND);
@@ -185,6 +216,71 @@ public class TimerServiceImpl implements TimerService {
                 .studyTime(studyTime)
                 .awayTime(awayTime)
                 .build();
+    }
+
+    private void updateStudyStatsAndDailyRecord(User user, int studyTime, int awayTime) {
+
+        // UserStudyStat 업데이트
+        UserStudyStat userStudyStat = userStudyStatRepo.findByUserId(user.getId())
+                .orElseGet(() -> {
+                    log.info("userId: {} 유저의 새로운 UserStudyStats 생성", user.getId());
+                    return UserStudyStat.builder()
+                            .user(user)
+                            .totalStudyTime(0)
+                            .totalAwayTime(0)
+                            .totalAttendanceDays(0)
+                            .continueAttendanceDays(0)
+                            .build();
+                });
+
+        userStudyStat.setTotalStudyTime(userStudyStat.getTotalStudyTime() + studyTime);
+        userStudyStat.setTotalAwayTime(userStudyStat.getTotalAwayTime() + awayTime);
+
+        // 출석일 업데이트
+        if (studyTime > 0) {
+            updateAttendance(userStudyStat);
+        }
+
+        userStudyStatRepo.save(userStudyStat);
+        log.info("UserStudyStat 업데이트 완료");
+
+        // DailyStudyRecord 업데이트
+        LocalDate today = LocalDate.now();
+        DailyStudyRecord dailyStudyRecord = dailyStudyRecordRepo
+                .findByUserIdAndRecordDate(user.getId(), today)
+                .orElseGet(() -> {
+                    log.info("userId: {} 유저의 오늘({}) DailyStudyRecord 생성", user.getId(), today);
+                    return DailyStudyRecord.builder()
+                            .user(user)
+                            .recordDate(today)
+                            .dailyStudyTime(0)
+                            .dailyAwayTime(0)
+                            .build();
+                });
+        dailyStudyRecord.setDailyStudyTime(dailyStudyRecord.getDailyStudyTime() + studyTime);
+        dailyStudyRecord.setDailyAwayTime(dailyStudyRecord.getDailyAwayTime() + awayTime);
+
+        dailyStudyRecordRepo.save(dailyStudyRecord);
+        log.info("DailyStudyRecord 업데이트 완료");
+    }
+
+    private void updateAttendance(UserStudyStat stat) {
+        LocalDate today = LocalDate.now();
+        LocalDate lastDate = stat.getLastAttendanceDate();
+
+        // 처음 출석하는 경우
+        if (lastDate == null || !lastDate.isEqual(today)) {
+            stat.setTotalAttendanceDays(stat.getTotalAttendanceDays() + 1);
+
+            // 연속 출석인지 확인
+            if (lastDate != null && lastDate.plusDays(1).isEqual(today)) {
+                stat.setContinueAttendanceDays(stat.getContinueAttendanceDays() +1);
+            } else {
+                stat.setContinueAttendanceDays(1);
+            }
+
+            stat.setLastAttendanceDate(today);
+        }
     }
 
     private TimerResponse buildTimerResponse(StudyRoomParticipant participant) {

--- a/livestudy/src/main/java/org/livestudy/service/UserStudyStatService.java
+++ b/livestudy/src/main/java/org/livestudy/service/UserStudyStatService.java
@@ -1,0 +1,16 @@
+package org.livestudy.service;
+
+import org.livestudy.dto.DailyRecordResponse;
+import org.livestudy.dto.UserStudyStatsResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface UserStudyStatService {
+
+    UserStudyStatsResponse getUserStudyStats(Long userId);
+
+    List<DailyRecordResponse> getDailyRecord(Long userId, LocalDate startDate, LocalDate endDate);
+
+    Double getAverageStudyRatio(Long userId, LocalDate startDate, LocalDate endDate);
+}

--- a/livestudy/src/main/java/org/livestudy/service/UserStudyStatServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/UserStudyStatServiceImpl.java
@@ -1,0 +1,97 @@
+package org.livestudy.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.livestudy.domain.user.DailyStudyRecord;
+import org.livestudy.domain.user.UserStudyStat;
+import org.livestudy.dto.DailyRecordResponse;
+import org.livestudy.dto.UserStudyStatsResponse;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.DailyStudyRecordRepository;
+import org.livestudy.repository.UserStudyStatRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserStudyStatServiceImpl implements UserStudyStatService{
+
+    private final UserStudyStatRepository userStudyStatRepo;
+    private final DailyStudyRecordRepository dailyStudyRecordRepo;
+
+    @Override
+    public UserStudyStatsResponse getUserStudyStats(Long userId) {
+
+        UserStudyStat userStudyStat = userStudyStatRepo.findByUserId(userId)
+                .orElseGet(() -> {
+                    log.error("userId: {} 유저의 공부 기록 통계를 찾을 수 없습니다. ", userId);
+                    throw new CustomException(ErrorCode.STAT_NOT_FOUND);
+                });
+
+        return UserStudyStatsResponse.from(userStudyStat);
+    }
+
+    @Override
+    public List<DailyRecordResponse> getDailyRecord(Long userId, LocalDate startDate, LocalDate endDate) {
+
+        List<DailyStudyRecord> records = dailyStudyRecordRepo
+                .findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                        userId, startDate, endDate
+                );
+
+        List<DailyRecordResponse> responses = records.stream()
+                .map(record -> DailyRecordResponse.builder()
+                        .recordDate(record.getRecordDate())
+                        .dailyStudyTime(record.getDailyStudyTime())
+                        .dailyAwayTime(record.getDailyAwayTime())
+                        .focusRatio(record.getFocusRatio())
+                        .build())
+                .toList();
+
+        if (responses.isEmpty()) {
+            log.warn("userId: {} 유저의 {} 부터 {} 까지의 일별 집중도 기록이 없습니다.",
+                    userId, startDate, endDate);
+        }
+
+        return responses;
+    }
+
+    @Override
+    public Double getAverageStudyRatio(Long userId, LocalDate startDate, LocalDate endDate) {
+
+        List<DailyStudyRecord> records = dailyStudyRecordRepo
+                .findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                        userId, startDate, endDate
+                );
+
+        if (records.isEmpty()) {
+            log.warn("userId: {} 유저의 {} 부터 {} 까지의 기록이 없어 평균 집중률을 계산할 수 없습니다.",
+                    userId, startDate, endDate);
+            return 0.0;
+        }
+
+        double totalStudyTime = 0.0;
+        double totalTime = 0.0;
+
+        for (DailyStudyRecord dailyStudyRecord: records) {
+            int dailyStudy = dailyStudyRecord.getDailyStudyTime();
+            int dailyAway = dailyStudyRecord.getDailyAwayTime();
+            int dailyTotal = dailyStudy + dailyAway;
+
+            if (dailyTotal > 0) {
+                totalStudyTime += dailyStudy;
+                totalTime += dailyTotal;
+            }
+        }
+
+        if (totalTime == 0) {
+            return 0.0;
+        }
+
+        return Math.round((totalStudyTime / totalTime) * 1000.0) / 10.0;
+    }
+}

--- a/livestudy/src/test/java/org/livestudy/service/UserStudyStatServiceTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/UserStudyStatServiceTest.java
@@ -1,0 +1,283 @@
+package org.livestudy.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.livestudy.domain.user.DailyStudyRecord;
+import org.livestudy.domain.user.User;
+import org.livestudy.domain.user.UserStudyStat;
+import org.livestudy.dto.DailyRecordResponse;
+import org.livestudy.dto.UserStudyStatsResponse;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.DailyStudyRecordRepository;
+import org.livestudy.repository.UserStudyStatRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections; // Collections.emptyList()를 사용하기 위함
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.data.Offset.offset;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserStudyStatServiceTest {
+
+    @Mock
+    private UserStudyStatRepository userStudyStatRepo;
+
+    @Mock
+    private DailyStudyRecordRepository dailyStudyRecordRepo;
+
+    @InjectMocks
+    private UserStudyStatServiceImpl userStudyStatService;
+
+    private User testUser;
+    private LocalDate fixedToday; // 테스트 날짜
+    private LocalDate fixedSixDaysAgo; // 테스트 날짜 6일 전(오늘 포함 7일)
+
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .nickname("testUser")
+                .build();
+        fixedToday = LocalDate.of(2025, 7, 29); // 오늘을 2025년 7월 29일
+        fixedSixDaysAgo = fixedToday.minusDays(6); // 2025년 7월 23일
+    }
+
+    @Test
+    @DisplayName("유저의 공부 통계 조회 성공")
+    void getUserStudyStats_success() {
+        // Given
+        UserStudyStat mockUserStudyStat = UserStudyStat.builder()
+                .user(testUser)
+                .totalStudyTime(36000)
+                .totalAwayTime(3600)
+                .totalAttendanceDays(10)
+                .continueAttendanceDays(5)
+                .lastAttendanceDate(LocalDate.of(2025, 7, 28))
+                .build();
+
+        when(userStudyStatRepo.findByUserId(testUser.getId())).thenReturn(Optional.of(mockUserStudyStat));
+
+        // When
+        UserStudyStatsResponse response = userStudyStatService.getUserStudyStats(testUser.getId());
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getUserId()).isEqualTo(testUser.getId());
+        assertThat(response.getNickname()).isEqualTo(testUser.getNickname());
+        assertThat(response.getTotalStudyTime()).isEqualTo(36000);
+        assertThat(response.getTotalAwayTime()).isEqualTo(3600);
+        assertThat(response.getTotalAttendanceDays()).isEqualTo(10);
+        assertThat(response.getContinueAttendanceDays()).isEqualTo(5);
+        assertThat(response.getLastAttendanceDate()).isEqualTo(LocalDate.of(2025, 7, 28));
+    }
+
+    @Test
+    @DisplayName("유저의 공부 통계 조회 실패")
+    void getUserStudyStats_notFound() {
+        // Given
+        when(userStudyStatRepo.findByUserId(any(Long.class))).thenReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userStudyStatService.getUserStudyStats(999L));
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.STAT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("DailyRecord 조회 성공")
+    void getDailyRecord_success() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 7, 26);
+        LocalDate endDate = LocalDate.of(2025, 7, 28);
+
+        DailyStudyRecord record1 = DailyStudyRecord.builder()
+                .id(1L).user(testUser).recordDate(LocalDate.of(2025, 7, 26))
+                .dailyStudyTime(3600).dailyAwayTime(600).build();
+        DailyStudyRecord record2 = DailyStudyRecord.builder()
+                .id(2L).user(testUser).recordDate(LocalDate.of(2025, 7, 27))
+                .dailyStudyTime(7200).dailyAwayTime(1800).build();
+        DailyStudyRecord record3 = DailyStudyRecord.builder()
+                .id(3L).user(testUser).recordDate(LocalDate.of(2025, 7, 28))
+                .dailyStudyTime(1800).dailyAwayTime(200).build();
+
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), startDate, endDate))
+                .thenReturn(Arrays.asList(record1, record2, record3));
+
+        // When
+        List<DailyRecordResponse> responses = userStudyStatService.getDailyRecord(testUser.getId(), startDate, endDate);
+
+        // Then
+        assertThat(responses).isNotNull();
+        assertThat(responses).hasSize(3);
+
+        assertThat(responses.get(0).getRecordDate()).isEqualTo(LocalDate.of(2025, 7, 26));
+        assertThat(responses.get(0).getDailyStudyTime()).isEqualTo(3600);
+        assertThat(responses.get(0).getDailyAwayTime()).isEqualTo(600);
+        assertThat(responses.get(0).getFocusRatio()).isCloseTo(85.71, offset(0.01));
+
+        assertThat(responses.get(1).getRecordDate()).isEqualTo(LocalDate.of(2025, 7, 27));
+        assertThat(responses.get(1).getDailyStudyTime()).isEqualTo(7200);
+        assertThat(responses.get(1).getDailyAwayTime()).isEqualTo(1800);
+        assertThat(responses.get(1).getFocusRatio()).isCloseTo(80.00, offset(0.01));
+
+        assertThat(responses.get(2).getRecordDate()).isEqualTo(LocalDate.of(2025, 7, 28));
+        assertThat(responses.get(2).getDailyStudyTime()).isEqualTo(1800);
+        assertThat(responses.get(2).getDailyAwayTime()).isEqualTo(200);
+        assertThat(responses.get(2).getFocusRatio()).isCloseTo(90.00, offset(0.01));
+    }
+
+    @Test
+    @DisplayName("일별 기록이 없는 경우 빈 리스트 조회")
+    void getDailyRecord_noRecords() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 7, 1);
+        LocalDate endDate = LocalDate.of(2025, 7, 7);
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), startDate, endDate))
+                .thenReturn(Collections.emptyList());
+
+        // When
+        List<DailyRecordResponse> responses = userStudyStatService.getDailyRecord(testUser.getId(), startDate, endDate);
+
+        // Then
+        assertThat(responses).isNotNull();
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("날짜 파라미터가 없는 경우 7일간의 데이터 조회")
+    void getDailyRecord_withDefaultDates() {
+        // Given
+        DailyStudyRecord record1 = DailyStudyRecord.builder()
+                .id(10L).user(testUser).recordDate(fixedSixDaysAgo)
+                .dailyStudyTime(1000).dailyAwayTime(100).build();
+        DailyStudyRecord record2 = DailyStudyRecord.builder()
+                .id(11L).user(testUser).recordDate(fixedToday)
+                .dailyStudyTime(2000).dailyAwayTime(200).build();
+
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), fixedSixDaysAgo, fixedToday))
+                .thenReturn(Arrays.asList(record1, record2));
+
+        // When
+        List<DailyRecordResponse> responses = userStudyStatService.getDailyRecord(testUser.getId(), fixedSixDaysAgo, fixedToday);
+
+        // Then
+        assertThat(responses).isNotNull();
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getRecordDate()).isEqualTo(fixedSixDaysAgo);
+        assertThat(responses.get(1).getRecordDate()).isEqualTo(fixedToday);
+    }
+
+    @Test
+    @DisplayName("AverageStudyRatio 조회 성공")
+    void getAverageStudyRatio_success() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 7, 26);
+        LocalDate endDate = LocalDate.of(2025, 7, 28);
+
+        DailyStudyRecord record1 = DailyStudyRecord.builder()
+                .id(1L).user(testUser).recordDate(LocalDate.of(2025, 7, 26))
+                .dailyStudyTime(3600).dailyAwayTime(600).build();
+        DailyStudyRecord record2 = DailyStudyRecord.builder()
+                .id(2L).user(testUser).recordDate(LocalDate.of(2025, 7, 27))
+                .dailyStudyTime(7200).dailyAwayTime(1800).build();
+        DailyStudyRecord record3 = DailyStudyRecord.builder()
+                .id(3L).user(testUser).recordDate(LocalDate.of(2025, 7, 28))
+                .dailyStudyTime(1800).dailyAwayTime(200).build();
+        DailyStudyRecord record4_zero_time = DailyStudyRecord.builder()
+                .id(4L).user(testUser).recordDate(LocalDate.of(2025, 7, 25))
+                .dailyStudyTime(0).dailyAwayTime(0).build();
+
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), startDate, endDate))
+                .thenReturn(Arrays.asList(record1, record2, record3, record4_zero_time));
+
+        // When
+        Double averageRatio = userStudyStatService.getAverageStudyRatio(testUser.getId(), startDate, endDate);
+
+        // Then
+        assertThat(averageRatio).isCloseTo(82.89, offset(0.01));
+    }
+
+    @Test
+    @DisplayName("기록이 없어 AverageStudyRatio 0.0 조회")
+    void getAverageStudyRatio_noRecords() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 7, 1);
+        LocalDate endDate = LocalDate.of(2025, 7, 7);
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), startDate, endDate))
+                .thenReturn(Collections.emptyList());
+
+        // When
+        Double averageRatio = userStudyStatService.getAverageStudyRatio(testUser.getId(), startDate, endDate);
+
+        // Then
+        assertThat(averageRatio).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("공부, 자리 비움 시간이 0일 경우 AverageStudyRatio 조회")
+    void getAverageStudyRatio_zeroTotalTime() {
+        // Given
+        LocalDate startDate = LocalDate.of(2025, 7, 1);
+        LocalDate endDate = LocalDate.of(2025, 7, 1);
+        DailyStudyRecord record = DailyStudyRecord.builder()
+                .id(1L).user(testUser).recordDate(LocalDate.of(2025, 7, 1))
+                .dailyStudyTime(0).dailyAwayTime(0).build();
+
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), startDate, endDate))
+                .thenReturn(Arrays.asList(record));
+
+        // When
+        Double averageRatio = userStudyStatService.getAverageStudyRatio(testUser.getId(), startDate, endDate);
+
+        // Then
+        assertThat(averageRatio).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("날짜 파라미터가 없는 경우 7일 간의 AverageStudyRatio 조회")
+    void getAverageStudyRatio_withDefaultDates() {
+        // Given
+        DailyStudyRecord record1 = DailyStudyRecord.builder()
+                .id(12L).user(testUser).recordDate(fixedSixDaysAgo)
+                .dailyStudyTime(1000).dailyAwayTime(100).build(); // 1000/1100 = 90.90%
+        DailyStudyRecord record2 = DailyStudyRecord.builder()
+                .id(13L).user(testUser).recordDate(fixedToday.minusDays(3))
+                .dailyStudyTime(500).dailyAwayTime(500).build();  // 500/1000 = 50.00%
+        DailyStudyRecord record3 = DailyStudyRecord.builder()
+                .id(14L).user(testUser).recordDate(fixedToday)
+                .dailyStudyTime(2000).dailyAwayTime(0).build();   // 2000/2000 = 100.00%
+
+        when(dailyStudyRecordRepo.findByUserIdAndRecordDateBetweenOrderByRecordDateAsc(
+                testUser.getId(), fixedSixDaysAgo, fixedToday))
+                .thenReturn(Arrays.asList(record1, record2, record3));
+
+        // When
+        Double averageRatio = userStudyStatService.getAverageStudyRatio(testUser.getId(), fixedSixDaysAgo, fixedToday);
+
+        // Then
+        // 총 학습 시간 = 1000 + 500 + 2000 = 3500
+        // 총 전체 시간 = 1100 + 1000 + 2000 = 4100
+        // 평균 학습률 = (3500 / 4100) * 100 = 85.36...
+        assertThat(averageRatio).isCloseTo(85.4, offset(0.01)); // 반올림(Math.round)
+    }
+}


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 유저의 마이페이지 및 통계 페이지에 들어가는 공부 데이터 조회 기능을 구현합니다.
 1. 유저의 마이페이지에는 '누적 공부 시간'을 제공합니다. 
 2. 유저의 통계 페이지에는 '누적 공부 시간', '총 출석일 수', '연속 출석일 수', '마지막 출석일 수', '일별 공부 시간', '일별 휴식 시간', '공부 집중률'을 제공합니다.
 3. 공부 집중률의 경우 일별 혹은 기간별로 조회할 수 있습니다(기간을 입력하지 않을 시 기본적으로 지난 7일간의 데이터 조회).
 4. 타이머 기능을 바탕으로 공부시간 혹은 휴식시간의 데이터가 누적됩니다.
 
# 변경된 사항
 1. ErrorCode.STAT_NOT_FOUND 코드 추가.
 2. TimerServiceImpl.java의 startFocus, pauseFocus, stopFocus 메서드를 통해 UserStudyStat, DailyStudyRecord 데이터 업데이트.
 3. UserStudyStatServiceImpl: 사용자 통계, 일별 기록, 평균 집중률을 계산하고 조회하는 로직 구현.
 4. UserProfileController: 마이페이지("/api/user/profile")에 누적 공부 시간 데이터 조회.
 5. UserStatController: 통계 페이지("/api/user/stat")에 기본 공부 관련 데이터 및 일별 집중도 추이, 기간별 집중률 데이터 조회.

# 테스트
 1. 단위 테스트 UserStudyStatServiceTest 추가: `UserStudyStatServiceImpl`의 코드와 Mock 객체를 사용한 의존성 간 상호작용을 독립적으로 검증합니다.
 
 