### PR TITLE
feat: 마이 페이지 조회, 수정 기능 구현

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
@@ -1,10 +1,11 @@
 package org.livestudy.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.livestudy.dto.UserStudyStatsResponse;
+import org.livestudy.dto.UserProfile.*;
 import org.livestudy.security.SecurityUser;
-import org.livestudy.service.UserStudyStatService;
+import org.livestudy.service.ProfileService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -15,19 +16,65 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/user/profile")
 public class UserProfileController {
 
-    private final UserStudyStatService userStudyStatService;
+    private final ProfileService profileService;
 
-    // 누적 공부시간
     @GetMapping
-    public ResponseEntity<UserStudyStatsResponse> getTotalStudyTime(
+    public ResponseEntity<UserProfileResponse> getUserProfile(
             @AuthenticationPrincipal SecurityUser user) {
+        Long userId = user.getUser().getId();
+        log.info("마이페이지 - userId: {} 유저의 프로필 조회", userId);
+
+        UserProfileResponse userProfile = profileService.getUserProfile(userId);
+        return ResponseEntity.ok(userProfile);
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<Void> updateNickname(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody UpdateNicknameRequest request) {
 
         Long userId = user.getUser().getId();
-        log.info("마이페이지 - userId: {} 유저의 총 공부시간", userId);
-        UserStudyStatsResponse statsResponse = userStudyStatService
-                .getUserStudyStats(userId);
 
-        return ResponseEntity.ok(statsResponse);
+        profileService.updateNickname(userId, request);
+
+        return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<Void> updateProfileImage(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody UpdateProfileImageRequest request) {
+
+        Long userId = user.getUser().getId();
+
+        profileService.updateProfileImage(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/email")
+    public ResponseEntity<Void> updateEmail(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody UpdateEmailRequest request) {
+
+        Long userId = user.getUser().getId();
+
+        profileService.updateEmail(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updatePassword(
+            @AuthenticationPrincipal SecurityUser user,
+            @Valid @RequestBody UpdatePasswordRequest request) {
+
+        Long userId = user.getUser().getId();
+
+        profileService.updatePassword(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
 
 }

--- a/livestudy/src/main/java/org/livestudy/domain/user/User.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/User.java
@@ -66,10 +66,7 @@ public class User extends BaseEntity {
                           String introduction,
                           String image, PasswordEncoder encoder) {
 
-        System.out.println("[User.of] email: " + email);
-        System.out.println("[User.of] raw password: " + password);
-        System.out.println("[User.of] encoded password: " + (password == null ? "null" : encoder.encode(password)));
-        return User.builder()
+         return User.builder()
                 .userTitle(userTitle)
                 .email(email)
                 .password(password == null ? null : encoder.encode(password))
@@ -104,4 +101,23 @@ public class User extends BaseEntity {
         this.equippedBadge = badge;
     }
 
+    // 닉네임 변경
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    // 프로필 이미지 변경
+    public void updateProfileImage(String newProfileImage) {
+        this.nickname = newProfileImage;
+    }
+
+    // 이메일 변경
+    public void updateEmail(String newEmail) {
+        this.email = newEmail;
+    }
+
+    // 패스워드 변경
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateEmailRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateEmailRequest.java
@@ -1,0 +1,18 @@
+package org.livestudy.dto.UserProfile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateEmailRequest {
+
+    @NotBlank
+    @Size(max = 100)
+    private String newEmail;
+
+}

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateNicknameRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateNicknameRequest.java
@@ -1,0 +1,18 @@
+package org.livestudy.dto.UserProfile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateNicknameRequest {
+
+    @NotBlank
+    @Size(max = 20)
+    private String newNickname;
+
+}

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdatePasswordRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdatePasswordRequest.java
@@ -1,0 +1,26 @@
+package org.livestudy.dto.UserProfile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePasswordRequest {
+
+    @NotBlank
+    @Size(max = 70)
+    private String currentPassword;
+
+    @NotBlank
+    @Size(max = 70)
+    private String newPassword;
+
+    @NotBlank
+    @Size(max = 70)
+    private String confirmNewPassword;
+
+}

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateProfileImageRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateProfileImageRequest.java
@@ -1,0 +1,18 @@
+package org.livestudy.dto.UserProfile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileImageRequest {
+
+    @NotBlank
+    @Size(max = 1024)
+    private String newProfileImage;
+
+}

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UserProfileResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UserProfileResponse.java
@@ -1,0 +1,14 @@
+package org.livestudy.dto.UserProfile;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileResponse {
+    private String profileImage;
+    private String nickname;
+    private String email;
+    private String selectedTitle;
+    private Integer totalStudyTime;
+}

--- a/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
+++ b/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
@@ -25,6 +25,10 @@ public enum ErrorCode {
     USER_WITHDRAW("U011", "탈퇴한 사용자입니다.", HttpStatus.FORBIDDEN),
     TITLE_NOT_FOUND("U012", "존재하지 않는 칭호입니다.", HttpStatus.BAD_REQUEST),
     NOT_EARNED_TITLE_YET("U013", "아직 취득하지 못한 칭호입니다.", HttpStatus.FORBIDDEN),
+    SAME_NICKNAME("U014", "현재 사용 중인 닉네임으로는 변경하실 수 없습니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_NICKNAME("U015", "이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
+    SAME_EMAIL("U016", "현재 사용 중인 이메일로는 변경하실 수 없습니다.", HttpStatus.BAD_REQUEST),
+    SAME_PASSWORD("U017", "현재 사용 중인 비밀번호로는 변경하실 수 없습니다.", HttpStatus.BAD_REQUEST),
 
 
     // Track 관련 에러

--- a/livestudy/src/main/java/org/livestudy/repository/UserRepository.java
+++ b/livestudy/src/main/java/org/livestudy/repository/UserRepository.java
@@ -25,4 +25,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndSocialProvider(String email, SocialProvider socialProvider);
 
     Optional<User> findByUserId(Long userId);
+
+    Boolean existsByNickname(String nickname);
+
+    Boolean existsByEmail(String Email);
+
 }

--- a/livestudy/src/main/java/org/livestudy/service/ProfileService.java
+++ b/livestudy/src/main/java/org/livestudy/service/ProfileService.java
@@ -1,0 +1,16 @@
+package org.livestudy.service;
+
+import org.livestudy.dto.UserProfile.*;
+
+public interface ProfileService {
+
+    UserProfileResponse getUserProfile(Long userId);
+
+    void updateNickname(Long userId, UpdateNicknameRequest request);
+
+    void updateProfileImage(Long userId, UpdateProfileImageRequest request);
+
+    void updateEmail(Long userId, UpdateEmailRequest request);
+
+    void updatePassword(Long userId, UpdatePasswordRequest request);
+}

--- a/livestudy/src/main/java/org/livestudy/service/ProfileServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/ProfileServiceImpl.java
@@ -1,0 +1,159 @@
+package org.livestudy.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.livestudy.domain.user.User;
+import org.livestudy.domain.user.UserStudyStat;
+import org.livestudy.dto.UserProfile.*;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.UserRepository;
+import org.livestudy.repository.UserStudyStatRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfileServiceImpl implements ProfileService{
+
+    private final UserRepository userRepo;
+    private final UserStudyStatRepository userStudyStatRepo;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserProfileResponse getUserProfile(Long userId) {
+
+        // User 엔티티 조회
+        User user = getUserById(userId);
+
+        // UserStudyStat 엔티티 조회
+        UserStudyStat userStudyStat = userStudyStatRepo.findByUserId(userId)
+                .orElse(null);
+
+        // 칭호
+        String selectedTitleName = null;
+        if (user.getUserTitle() != null && user.getUserTitle().getTitle() != null) {
+            selectedTitleName = user.getUserTitle().getTitle().getName();
+        }
+
+        return UserProfileResponse.builder()
+                .profileImage(user.getProfileImage())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .selectedTitle(selectedTitleName)
+                .totalStudyTime(userStudyStat != null ?
+                        userStudyStat.getTotalStudyTime() : 0)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateNickname(Long userId, UpdateNicknameRequest request) {
+
+        // User 엔티티 조회
+        User user = getUserById(userId);
+        String newNickname = request.getNewNickname();
+
+        // 현재 닉네임과 동일한지 체크
+        if (user.getNickname().equals(newNickname)) {
+            log.error("userId: {} 유저의 닉네임 변경이 실패하였습니다. 사유: SAME_NICKNAME", userId);
+            throw new CustomException(ErrorCode.SAME_NICKNAME);
+        }
+        // 사용 중인 닉네임인지 체크
+        if (userRepo.existsByNickname(newNickname)) {
+            log.error("userId: {} 유저의 닉네임 변경이 실패하였습니다. 사유: DUPLICATE_NICKNAME", userId);
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+
+        user.updateNickname(newNickname);
+        userRepo.save(user);
+        log.info("userId: {} 유저의 닉네임이 '{}'로 변경되었습니다.", userId, newNickname);
+
+
+    }
+
+    @Override
+    @Transactional
+    public void updateProfileImage(Long userId, UpdateProfileImageRequest request) {
+
+        // User 엔티티 조회
+        User user = getUserById(userId);
+        String newProfileImage = request.getNewProfileImage();
+
+        // 현재 이미지와 동일한지 체크
+        if (user.getProfileImage() != null && user.getProfileImage().equals(newProfileImage)) {
+            log.warn("userId: {} 유저의 프로필 이미지가 동일한 이미지로 변경이 요청되었습니다.", userId);
+            return;
+        }
+
+        user.updateProfileImage(newProfileImage);
+        userRepo.save(user);
+        log.info("userId: {} 유저의 프로필 이미지가 변경되었습니다.", userId);
+
+    }
+
+    @Override
+    @Transactional
+    public void updateEmail(Long userId, UpdateEmailRequest request) {
+
+        // User 엔티티 조회
+        User user = getUserById(userId);
+        String newEmail = request.getNewEmail();
+
+        // 현재 이메일과 동일한지 체크
+        if (user.getEmail().equals(newEmail)) {
+            log.error("userId: {} 유저의 이메일 변경이 실패하였습니다. 사유: SAME_EMAIL", userId);
+            throw new CustomException(ErrorCode.SAME_EMAIL);
+        }
+        // 이미 사용 중인 이메일인지 체크
+        if (userRepo.existsByEmail(newEmail)) {
+            log.error("userId: {} 유저의 이메일 변경이 실패하였습니다. 사유: DUPLICATE_EMAIL", userId);
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+
+        user.updateEmail(newEmail);
+        userRepo.save(user);
+        log.info("userId: {} 유저의 이메일이 '{}'로 변경되었습니다.", userId, newEmail);
+
+    }
+
+    @Override
+    @Transactional
+    public void updatePassword(Long userId, UpdatePasswordRequest request) {
+
+        // User 엔티티 조회
+        User user = getUserById(userId);
+
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            log.error("userId: {} 유저의 비밀번호가 일치하지 않아 변경에 실패합니다.", userId);
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+        String newPassword = request.getNewPassword();
+
+        // 현재 비밀번호와 동일한지 체크
+        if (passwordEncoder.matches(newPassword, user.getPassword())) {
+            log.error("userId: {} 유저의 비밀번호 변경이 실패하였습니다. 사유: SAME_PASSWORD", userId);
+            throw new CustomException(ErrorCode.SAME_PASSWORD);
+        }
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        userRepo.save(user);
+        log.info("userId: {} 유저의 비밀번호가 변경되었습니다.", userId);
+
+    }
+
+    private User getUserById(Long userId) {
+        return userRepo.findByUserId(userId)
+                .orElseThrow(() -> {
+                    log.error("userId: {} 유저를 찾을 수 없습니다.", userId);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND);
+                });
+    }
+
+
+}

--- a/livestudy/src/test/java/org/livestudy/service/ProfileServiceImplTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/ProfileServiceImplTest.java
@@ -1,0 +1,369 @@
+package org.livestudy.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.livestudy.domain.user.User;
+import org.livestudy.domain.user.UserStudyStat;
+import org.livestudy.dto.UserProfile.*;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.UserRepository;
+import org.livestudy.repository.UserStudyStatRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @InjectMocks
+    private ProfileServiceImpl profileService;
+
+    @Mock
+    private UserRepository userRepo;
+    @Mock
+    private UserStudyStatRepository userStudyStatRepo;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+    private UserStudyStat testUserStudyStat;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 User 객체 생성
+        testUser = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .password("encodedPassword123")
+                .nickname("testuser")
+                .profileImage("http://example.com/image.jpg")
+                .build();
+
+        // 테스트용 UserStudyStat 객체 생성
+        testUserStudyStat = UserStudyStat.builder()
+                .id(1L)
+                .user(testUser)
+                .totalStudyTime(1200)
+                .build();
+    }
+
+    @Test
+    @DisplayName("프로필 조회 성공")
+    void getUserProfile_Success() {
+        // Given (상황 설정)
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(userStudyStatRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUserStudyStat));
+
+        // When (행위)
+        UserProfileResponse response = profileService.getUserProfile(testUser.getId());
+
+        // Then (결과 검증)
+        assertThat(response).isNotNull();
+        assertThat(response.getNickname()).isEqualTo(testUser.getNickname());
+        assertThat(response.getEmail()).isEqualTo(testUser.getEmail());
+        assertThat(response.getProfileImage()).isEqualTo(testUser.getProfileImage());
+        assertThat(response.getTotalStudyTime()).isEqualTo(testUserStudyStat.getTotalStudyTime());
+
+        // verify (호출 검증)
+        verify(userRepo).findByUserId(testUser.getId());
+        verify(userStudyStatRepo).findByUserId(testUser.getId());
+    }
+
+    @Test
+    @DisplayName("프로필 조회 실패 - 유저를 찾을 수 없음")
+    void getUserProfile_UserNotFound() {
+        // Given
+        given(userRepo.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.getUserProfile(999L)); // 존재하지 않는 ID
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        verify(userRepo).findByUserId(999L);
+        verify(userStudyStatRepo, never()).findByUserId(any(Long.class)); // 유저 없으면 통계 조회 안 함
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void updateNickname_Success() {
+        // Given
+        String newNickname = "newuser";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(userRepo.existsByNickname(newNickname)).willReturn(false); // 중복 아님
+
+        // When
+        profileService.updateNickname(testUser.getId(), request);
+
+        // Then (확인)
+        assertThat(testUser.getNickname()).isEqualTo(newNickname);
+        verify(userRepo).save(testUser);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 실패 - 현재 닉네임과 동일")
+    void updateNickname_SameNickname() {
+        // Given
+        String currentNickname = testUser.getNickname();
+        UpdateNicknameRequest request = new UpdateNicknameRequest(currentNickname);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateNickname(testUser.getId(), request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SAME_NICKNAME);
+        verify(userRepo, never()).existsByNickname(any(String.class));
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 실패 - 이미 사용 중인 닉네임")
+    void updateNickname_DuplicateNickname() {
+        // Given
+        String newNickname = "existinguser";
+        UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(userRepo.existsByNickname(newNickname)).willReturn(true); // 중복임
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateNickname(testUser.getId(), request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+        verify(userRepo).existsByNickname(newNickname);
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 실패 - 유저를 찾을 수 없음")
+    void updateNickname_UserNotFound() {
+        // Given
+        UpdateNicknameRequest request = new UpdateNicknameRequest("anyNickname");
+        given(userRepo.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateNickname(999L, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        verify(userRepo, never()).existsByNickname(any(String.class));
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변경 성공")
+    void updateProfileImage_Success() {
+        // Given
+        String newImageUrl = "http://new.example.com/image.jpg";
+        UpdateProfileImageRequest request = new UpdateProfileImageRequest(newImageUrl);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+
+        // When
+        profileService.updateProfileImage(testUser.getId(), request);
+
+        // Then
+        assertThat(testUser.getProfileImage()).isEqualTo(newImageUrl);
+        verify(userRepo).save(testUser);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변경 성공 - 현재 이미지와 동일하면 경고 후 저장 안함")
+    void updateProfileImage_SameImage() {
+        // Given
+        String currentImageUrl = testUser.getProfileImage();
+        UpdateProfileImageRequest request = new UpdateProfileImageRequest(currentImageUrl);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+
+        // When
+        profileService.updateProfileImage(testUser.getId(), request);
+
+        // Then (save 메서드가 호출되지 않았는지 확인)
+        verify(userRepo, never()).save(any(User.class));
+        // User 엔티티의 프로필 이미지는 변경되지 않아야 함
+        assertThat(testUser.getProfileImage()).isEqualTo(currentImageUrl);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변경 실패 - 유저를 찾을 수 없음")
+    void updateProfileImage_UserNotFound() {
+        // Given
+        UpdateProfileImageRequest request = new UpdateProfileImageRequest("anyImageUrl");
+        given(userRepo.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateProfileImage(999L, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이메일 변경 성공")
+    void updateEmail_Success() {
+        // Given
+        String newEmail = "new@example.com";
+        UpdateEmailRequest request = new UpdateEmailRequest(newEmail);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(userRepo.existsByEmail(newEmail)).willReturn(false);
+
+        // When
+        profileService.updateEmail(testUser.getId(), request);
+
+        // Then
+        assertThat(testUser.getEmail()).isEqualTo(newEmail);
+        verify(userRepo).save(testUser);
+    }
+
+    @Test
+    @DisplayName("이메일 변경 실패 - 현재 이메일과 동일")
+    void updateEmail_SameEmail() {
+        // Given
+        String currentEmail = testUser.getEmail();
+        UpdateEmailRequest request = new UpdateEmailRequest(currentEmail);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateEmail(testUser.getId(), request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SAME_EMAIL);
+        verify(userRepo, never()).existsByEmail(any(String.class));
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이메일 변경 실패 - 이미 사용 중인 이메일")
+    void updateEmail_DuplicateEmail() {
+        // Given
+        String newEmail = "another@example.com";
+        UpdateEmailRequest request = new UpdateEmailRequest(newEmail);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(userRepo.existsByEmail(newEmail)).willReturn(true); // 중복임
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateEmail(testUser.getId(), request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+        verify(userRepo).existsByEmail(newEmail);
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이메일 변경 실패 - 유저를 찾을 수 없음")
+    void updateEmail_UserNotFound() {
+        // Given
+        UpdateEmailRequest request = new UpdateEmailRequest("any@email.com");
+        given(userRepo.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updateEmail(999L, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        verify(userRepo, never()).existsByEmail(any(String.class));
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void updatePassword_Success() {
+        // Given
+        String currentPassword = "oldPassword123";
+        String newPassword = "newPassword456";
+        UpdatePasswordRequest request = new UpdatePasswordRequest(currentPassword, newPassword, newPassword); // confirmNewPassword는 백엔드에서 검증 안 함
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches(currentPassword, testUser.getPassword())).willReturn(true); // 현재 비밀번호 일치
+        given(passwordEncoder.matches(newPassword, testUser.getPassword())).willReturn(false); // 새 비밀번호가 현재와 다름
+        given(passwordEncoder.encode(newPassword)).willReturn("encodedNewPassword456");
+
+        // When
+        profileService.updatePassword(testUser.getId(), request);
+
+        // Then
+        assertThat(testUser.getPassword()).isEqualTo("encodedNewPassword456");
+        verify(userRepo).save(testUser);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 현재 비밀번호 불일치")
+    void updatePassword_InvalidCurrentPassword() {
+        // Given
+        String wrongPassword = "wrongPassword";
+        String newPassword = "newPassword456";
+        UpdatePasswordRequest request = new UpdatePasswordRequest(wrongPassword, newPassword, newPassword);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches(wrongPassword, testUser.getPassword())).willReturn(false); // 현재 비밀번호 불일치
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updatePassword(testUser.getId(), request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PASSWORD);
+        verify(passwordEncoder).matches(wrongPassword, testUser.getPassword());
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 새 비밀번호가 현재 비밀번호와 동일")
+    void updatePassword_SameAsCurrentPassword() {
+        // Given
+        String currentPassword = "oldPassword123";
+        String newPassword = "oldPassword123";
+        UpdatePasswordRequest request = new UpdatePasswordRequest(currentPassword, newPassword, newPassword);
+
+        given(userRepo.findByUserId(testUser.getId())).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches(currentPassword, testUser.getPassword())).willReturn(true); // 현재 비밀번호 일치
+        given(passwordEncoder.matches(newPassword, testUser.getPassword())).willReturn(true); // 새 비밀번호가 현재와 동일
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updatePassword(testUser.getId(), request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SAME_PASSWORD);
+        verify(passwordEncoder).matches(currentPassword, testUser.getPassword());
+        verify(passwordEncoder).matches(newPassword, testUser.getPassword());
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 유저를 찾을 수 없음")
+    void updatePassword_UserNotFound() {
+        // Given
+        UpdatePasswordRequest request = new UpdatePasswordRequest("current", "new", "new");
+        given(userRepo.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> profileService.updatePassword(999L, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        verify(userRepo, never()).save(any(User.class));
+    }
+}


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 유저의 마이페이지에 들어가는 유저데이터 조회 및 수정 기능을 구현합니다.
 1. 유저의 마이페이지에는 '프로필 이미지', '닉네임', '이메일 주소', '누적 공부 시간'를 조회할 수 있습니다. 
 2. 유저의 마이페이지에는 '프로필 이미지', '닉네임', '이메일 주소', '비밀번호'를 수정할 수 있습니다.
 3. '닉네임', '이메일 주소' 수정 시, 현재 사용 중인 것과 같거나 다른 사람이 이미 사용 중이면 오류가 발생합니다.
 4. '프로필 이미지' 수정 시, 현재 사용 중인 이미지와 동일하면 경고를 log에 저 후, 이미지를 변경하지 않습니다.
 5. '비밀번호' 수정
    - 현재 비밀번호를 확인하여 일치하지 않으면 오류가 발생합니다.
    - passwordEncoder를 이용하여 인코딩 후 변경합니다.
 
# 변경된 사항
 1. ErrorCode의 변경 오류 코드 추가(SAME, DUPLICATE)
 2. ProfileServiceImpl.java
    - getUserProfile 메서드를 통해 유저 데이터 조회.
    - updateNickname, updateProfileImage, updateEmail, updatePassword 메서드를 통해 유저 데이터 수정.
 3. UserProfileController
    - 마이페이지("/api/user/profile")에 유저 데이터 조회.
    - 마이페이지("/api/user/profile")의 PatchMapping(/nickname, /profile, /email, /password)를 사용하여 유저 데이터 수정.

# 테스트
 1. 단위 테스트 ProfileServiceTest 추가: `ProfileServiceImpl`의 코드와 Mock 객체를 사용한 의존성 간 상호작용을 독립적으로 검증합니다.