### PR TITLE
chore: OAuth2 설정 값 입력

### DIFF
--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -23,25 +23,26 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 
 # OAuth2 Client Registration
 # Google OAuth2
-spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:your-google-client-id}
-spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+spring.security.oauth2.client.registration.google.client-id=52046583081-ihlomiiibi4iggbs6bkicd768mfkg2jq.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
 spring.security.oauth2.client.registration.google.scope=email,profile
-spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/api/auth/oauth2/callback/{registrationId}
+spring.security.oauth2.client.registration.google.redirect-uri=https://live-study.com/api/auth/oauth2/callback/google
+
 
 # Kakao OAuth2
-spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID:your-kakao-client-id}
-spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
+spring.security.oauth2.client.registration.kakao.client-id=98521588a69d7a6c3945fb4307caebad
+spring.security.oauth2.client.registration.kakao.client-secret=dgHpBourPgbcbgJ1JKyaSqmqLI5p2syX
 spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/api/auth/oauth2/callback/{registrationId}
+spring.security.oauth2.client.registration.kakao.redirect-uri=https://live-study.com/api/auth/oauth2/callback/kakao
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
 
 # Naver OAuth2
-spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENT_ID:your-naver-client-id}
-spring.security.oauth2.client.registration.naver.client-secret=${NAVER_CLIENT_SECRET:your-naver-client-secret}
+spring.security.oauth2.client.registration.naver.client-id=bOs4Dsopdpf7V6UC3B6n
+spring.security.oauth2.client.registration.naver.client-secret=X5BRSMACij
 spring.security.oauth2.client.registration.naver.scope=name,email,profile_image
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.naver.redirect-uri={baseUrl}/api/auth/oauth2/callback/{registrationId}
+spring.security.oauth2.client.registration.naver.redirect-uri=https://www.live-study.com/api/auth/oauth2/callback/naver
 spring.security.oauth2.client.registration.naver.client-name=Naver
 
 # OAuth2 Provider


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 소셜 로그인(GOOGLE, KAKAO, NAVER) 기능을 위한 필수 값을 설정합니다.
 1. 각 회사의 개발자 센터에서 발급받은 API, SECRET, URI 값을 입력했습니다.
 
# 변경된 사항
 1. 'application.properties'의 각 Oauth2의 API-KEY, SECRET-KEY, REDIRECT-URI 값 입력