### PR TITLE
fix : cors-security-configuration

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -99,7 +99,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5174", "https://live-study.com"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
CORS 오류가 발생한다고 해서 찾아보니까 SecurityConfig에서 setAllowedOriginPatterns(Arrays.asList("*"))랑 setAllowedHeaders(Arrays.asList("*"))랑 같이 사용되고 있는 점이 확인되었습니다.

도메인이 없었기에, 이렇게 설정을 하셔서 진행하신 것 같은데, 지금은 FE와 연동이 되고 도메인이 확보되었기에, 이 부분에 대해서 하기와 같이 변경합니다. Before
setAllowedOriginPatterns(Arrays.asList("*"))
After
setAllowedOrigins(Arrays.asList("http://localhost:5174", "https://live-study.com"))

참고 부탁 드리겠습니다. 이 Branch에서는 SecurityConfig만 변경하여 올립니다!