### PR TITLE
refactor: swagger 어노테이션 추가

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/OAuth2CallbackController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/OAuth2CallbackController.java
@@ -1,5 +1,12 @@
 package org.livestudy.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.livestudy.domain.user.SocialProvider;
 import org.livestudy.domain.user.User;
@@ -24,6 +31,7 @@ import java.util.Map;
 
 @Slf4j
 @Controller
+@Tag(name = "소셜 로그인 콜백 API", description = "OAuth2 콜백 처리")
 public class OAuth2CallbackController {
 
     private final UserService userService;
@@ -50,6 +58,16 @@ public class OAuth2CallbackController {
 
 
     @GetMapping("/api/auth/oauth2/callback/google")
+    @Operation(summary = "Google OAuth2 콜백 처리",
+            description = "Google OAuth2 인증 후 리디렉션된 요청을 처리하고, 사용자 정보를 기반으로 로그인/회원가입을 진행한 후 프론트엔드로 최종 리디렉션합니다.")
+    @Parameters({
+            @Parameter(name = "code", description = "Google OAuth2 인증 서버로부터 받은 인가 코드"),
+            @Parameter(name = "state", description = "OAuth2 흐름 중 CSRF 공격 방지를 위해 사용되는 상태 값 (선택 사항)", required = false)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "인증 성공 또는 실패 후 프론트엔드 URI로 리디렉션됩니다.",
+                    headers = @Header(name = "Location", description = "리디렉션될 프론트엔드 URL (성공 시: token, email, isNewUser 포함 / 실패 시: error 포함)"))
+    })
     public void googleOAuth2Callback(@RequestParam("code") String code,
                                      @RequestParam(value = "state", required = false) String state,
                                      HttpServletResponse response) throws IOException {

--- a/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
@@ -1,9 +1,17 @@
 package org.livestudy.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.livestudy.dto.ErrorResponse;
 import org.livestudy.dto.UserProfile.*;
+import org.livestudy.dto.report.ReportRequest;
 import org.livestudy.security.SecurityUser;
 import org.livestudy.service.ProfileService;
 import org.springframework.http.ResponseEntity;
@@ -14,11 +22,23 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user/profile")
+@Tag(name = "마이페이지 API", description = "마이페이지 데이터 조회/수정 API")
 public class UserProfileController {
 
     private final ProfileService profileService;
 
     @GetMapping
+    @Operation(summary = "프로필 조회", description = "유저(자신)에 대한 프로필 데이터를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "조회 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
     public ResponseEntity<UserProfileResponse> getUserProfile(
             @AuthenticationPrincipal SecurityUser user) {
         Long userId = user.getUser().getId();
@@ -29,6 +49,22 @@ public class UserProfileController {
     }
 
     @PatchMapping("/nickname")
+    @Operation(summary = "닉네임 수정", description = "유저(자신)의 닉네임을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임이 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "수정할 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "닉네임 수정 정보",
+            required = true,
+            content = @Content(schema = @Schema(implementation = UpdateNicknameRequest.class))
+    )
     public ResponseEntity<Void> updateNickname(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdateNicknameRequest request) {
@@ -40,7 +76,23 @@ public class UserProfileController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/profile")
+    @PatchMapping("/profileImage")
+    @Operation(summary = "프로필이미지 수정", description = "유저(자신)의 프로필 이미지를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이미지가 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "수정할 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "프로필이미지 수정 정보",
+            required = true,
+            content = @Content(schema = @Schema(implementation = UpdateProfileImageRequest.class))
+    )
     public ResponseEntity<Void> updateProfileImage(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdateProfileImageRequest request) {
@@ -53,6 +105,22 @@ public class UserProfileController {
     }
 
     @PatchMapping("/email")
+    @Operation(summary = "이메일 수정", description = "유저(자신)의 이메일을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이메일이 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "수정할 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "이메일 수정 정보",
+            required = true,
+            content = @Content(schema = @Schema(implementation = UpdateEmailRequest.class))
+    )
     public ResponseEntity<Void> updateEmail(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdateEmailRequest request) {
@@ -65,6 +133,22 @@ public class UserProfileController {
     }
 
     @PatchMapping("/password")
+    @Operation(summary = "비밀번호 수정", description = "유저(자신)의 비밀번호를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호가 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "수정할 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "비밀번호 수정 정보",
+            required = true,
+            content = @Content(schema = @Schema(implementation = UpdatePasswordRequest.class))
+    )
     public ResponseEntity<Void> updatePassword(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdatePasswordRequest request) {

--- a/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
@@ -1,9 +1,18 @@
 package org.livestudy.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.livestudy.dto.AverageFocusRatioResponse;
 import org.livestudy.dto.DailyRecordResponse;
+import org.livestudy.dto.ErrorResponse;
 import org.livestudy.dto.UserStudyStatsResponse;
 import org.livestudy.security.SecurityUser;
 import org.livestudy.service.UserStudyStatService;
@@ -22,12 +31,24 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user/stat")
+@Tag(name = "통계 페이지 API", description = "통계 페이지 데이터 조회")
 public class UserStatController {
 
     private final UserStudyStatService userStudyStatService;
 
     // 기본 데이터
     @GetMapping("/normal")
+    @Operation(summary = "공부 데이터 조회", description = "유저(자신)에 대한 공부 데이터를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "공부 데이터가 성공적으로 조회되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "조회 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
     public ResponseEntity<UserStudyStatsResponse> getUserNormalStats(
             @AuthenticationPrincipal SecurityUser user) {
 
@@ -40,7 +61,23 @@ public class UserStatController {
         return ResponseEntity.ok(statsResponse);
     }
 
+    // 일별 집중도 추이
     @GetMapping("/daily-focus")
+    @Operation(summary = "일별 집중도 추이 조회", description = "유저(자신)에 대한 일별 집중도 추이를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "집중도 추이가 성공적으로 조회되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "조회 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @Parameters({
+            @Parameter(name = "startDate", description = "시작일", example = "2025-07-22"),
+            @Parameter(name = "endDate", description = "종료일", example = "2025-08-01")
+    })
     public ResponseEntity<List<DailyRecordResponse>> getDailyFocus(
             @AuthenticationPrincipal SecurityUser user,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -58,7 +95,23 @@ public class UserStatController {
         return ResponseEntity.ok(dailyFocus);
     }
 
+    // 기간별 집중률
     @GetMapping("/average-focus-ratio")
+    @Operation(summary = "기간별 집중률 조회", description = "유저(자신)에 대한 기간별 집중률을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "기간별 집중률이 성공적으로 조회되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "조회 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @Parameters({
+            @Parameter(name = "startDate", description = "시작일", example = "2025-07-22"),
+            @Parameter(name = "endDate", description = "종료일", example = "2025-08-01")
+    })
     public ResponseEntity<AverageFocusRatioResponse> getAverageFocusRatio(
             @AuthenticationPrincipal SecurityUser user,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,

--- a/livestudy/src/main/java/org/livestudy/controller/report/ReportController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/report/ReportController.java
@@ -1,7 +1,14 @@
 package org.livestudy.controller.report;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.livestudy.dto.ErrorResponse;
 import org.livestudy.dto.report.ReportRequest;
 import org.livestudy.service.report.ReportService;
 import org.springframework.http.ResponseEntity;
@@ -14,13 +21,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/reports")
 @RequiredArgsConstructor
+@Tag(name = "신고 API", description = "유저 신고 접수/처리 API")
 public class ReportController {
 
     private final ReportService reportService;
 
     @PostMapping
+    @Operation(summary = "신고 접수", description = "특정 유저에 대한 신고를 접수합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "신고가 성공적으로 접수되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다(자기 자신 신고, 중복 신고 등).",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "신고 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "신고 요청 정보",
+            required = true,
+            content = @Content(schema = @Schema(implementation = ReportRequest.class))
+    )
     public ResponseEntity<Void> report(@Valid @RequestBody ReportRequest dto,
-                                 @AuthenticationPrincipal(expression = "id") Long userId) {
+                                       @AuthenticationPrincipal(expression = "id") Long userId) {
         reportService.report(dto.toCommand(), userId);
         return ResponseEntity.ok().build();
     }

--- a/livestudy/src/main/java/org/livestudy/domain/report/ReportReason.java
+++ b/livestudy/src/main/java/org/livestudy/domain/report/ReportReason.java
@@ -1,7 +1,16 @@
 package org.livestudy.domain.report;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "신고 사유 ENUM")
 public enum ReportReason {
+
+    @Schema(description = "음란물")
     OBSCENE_CONTENT,
+
+    @Schema(description = "욕설")
     ABUSE,
+
+    @Schema(description = "방해")
     DISTURBANCE
 }

--- a/livestudy/src/main/java/org/livestudy/domain/report/RestrictionSource.java
+++ b/livestudy/src/main/java/org/livestudy/domain/report/RestrictionSource.java
@@ -1,6 +1,13 @@
 package org.livestudy.domain.report;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "제재 주체 ENUM")
 public enum RestrictionSource {
+
+    @Schema(description = "이용자 제재")
     REPORT,
+
+    @Schema(description = "관리자 제재")
     ADMIN
 }

--- a/livestudy/src/main/java/org/livestudy/domain/report/RestrictionType.java
+++ b/livestudy/src/main/java/org/livestudy/domain/report/RestrictionType.java
@@ -1,6 +1,13 @@
 package org.livestudy.domain.report;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "신고 종류(타입) ENUM")
 public enum RestrictionType {
+
+    @Schema(description = "일시 정지")
     TEMPORARY,
+
+    @Schema(description = "영구 정지")
     PERMANENT
 }

--- a/livestudy/src/main/java/org/livestudy/domain/studyroom/FocusStatus.java
+++ b/livestudy/src/main/java/org/livestudy/domain/studyroom/FocusStatus.java
@@ -1,6 +1,13 @@
 package org.livestudy.domain.studyroom;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "집중 타입 ENUM")
 public enum FocusStatus {
+
+    @Schema(description = "공부 집중 상태")
     FOCUS,
+
+    @Schema(description = "자리비움 상태")
     AWAY
 }

--- a/livestudy/src/main/java/org/livestudy/domain/studyroom/StudyRoomStatus.java
+++ b/livestudy/src/main/java/org/livestudy/domain/studyroom/StudyRoomStatus.java
@@ -1,7 +1,16 @@
 package org.livestudy.domain.studyroom;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "스터디룸 상태 ENUM")
 public enum StudyRoomStatus {
+
+    @Schema(description = "열림(입장 가능)")
     OPEN,
+
+    @Schema(description = "열림(인원 수 초과로 입장 불가)")
     FULL,
+
+    @Schema(description = "닫힘")
     CLOSE
 }

--- a/livestudy/src/main/java/org/livestudy/domain/user/SocialProvider.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/SocialProvider.java
@@ -1,8 +1,19 @@
 package org.livestudy.domain.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 타입 ENUM")
 public enum SocialProvider {
+
+    @Schema(description = "일반 로그인")
     LOCAL,
+
+    @Schema(description = "구글 로그인")
     GOOGLE,
+
+    @Schema(description = "카카오 로그인")
     KAKAO,
+
+    @Schema(description = "네이버 로그인")
     NAVER
 }

--- a/livestudy/src/main/java/org/livestudy/domain/user/UserStatus.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/UserStatus.java
@@ -1,7 +1,16 @@
 package org.livestudy.domain.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 상태 ENUM")
 public enum UserStatus {
+
+    @Schema(description = "일반")
     NORMAL, // 평상시
+
+    @Schema(description = "일시 정지")
     TEMPORARY_BAN,  // 정지 당할 시 Status
+
+    @Schema(description = "영구 정지")
     PERMANENT_BAN  // 영구 삭제 당할 시 Status
 }

--- a/livestudy/src/main/java/org/livestudy/dto/AverageFocusRatioResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/AverageFocusRatioResponse.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,15 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "평군 집중률 응답 DTO")
 public class AverageFocusRatioResponse {
+
+    @Schema(description = "조회 시작일", example = "2025-07-22")
     private LocalDate startDate;
+
+    @Schema(description = "조회 종료일", example = "2025-07-29")
     private LocalDate endDate;
+
+    @Schema(description = "해당 기간의 평균 집중률", example = "0.34")
     private Double averageFocusRatio;
 }

--- a/livestudy/src/main/java/org/livestudy/dto/DailyRecordResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/DailyRecordResponse.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,9 +8,18 @@ import java.time.LocalDate;
 
 @Getter
 @Builder
+@Schema(description = "하루 기록 응답 DTO")
 public class DailyRecordResponse {
+
+    @Schema(description = "기록한 날짜", example = "2025-08-01")
     private LocalDate recordDate;
+
+    @Schema(description = "하루 공부 시간", example = "2222")
     private Long dailyStudyTime;
+
+    @Schema(description = "하루 자리 비움 시간", example = "1111")
     private Long dailyAwayTime;
+
+    @Schema(description = "하루 집중률", example = "0.53")
     private Double focusRatio;
 }

--- a/livestudy/src/main/java/org/livestudy/dto/ErrorResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/ErrorResponse.java
@@ -1,0 +1,12 @@
+package org.livestudy.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ErrorResponse {
+
+    private String errorCode;
+    private String message;
+}

--- a/livestudy/src/main/java/org/livestudy/dto/SocialLoginResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/SocialLoginResponse.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,12 +11,27 @@ import org.livestudy.domain.user.SocialProvider;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "소셜 로그인 응답 DTO")
 public class SocialLoginResponse {
+
+    @Schema(description = "발급 받은 토큰")
     private String token;
+
+    @Schema(description = "유저 ID", example = "1L")
     private Long userId;
+
+    @Schema(description = "유저 이메일", example = "new@example.com")
     private String email;
+
+    @Schema(description = "유저 닉네임", example = "열공이")
     private String nickname;
+
+    @Schema(description = "유저 프로필 이미지 주소", example = "https://newImage.com/profile.png")
     private String profileImage;
+
+    @Schema(description = "소셜 로그인 종류", example = "GOOGLE")
     private SocialProvider socialProvider;
+
+    @Schema(description = "신규 회원 여부", example = "true")
     private boolean isNewUser; // 신규 가입자인지 여부
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateEmailRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateEmailRequest.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto.UserProfile;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -9,10 +10,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "유저 이메일 수정 요청 DTO")
 public class UpdateEmailRequest {
 
-    @NotBlank
-    @Size(max = 100)
+    @NotBlank(message = "새로운 이메일은 비어있을 수 없습니다.")
+    @Size(max = 100, message = "최대 100자까지 입력하실 수 있습니다.")
+    @Schema(description = "새로운 이메일 주소", example = "new@example.com", maxLength = 100)
     private String newEmail;
 
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateNicknameRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateNicknameRequest.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto.UserProfile;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -9,10 +10,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "유저 닉네임 수정 요청 DTO")
 public class UpdateNicknameRequest {
 
-    @NotBlank
-    @Size(max = 20)
+    @NotBlank(message = "새로운 닉네임은 비어있을 수 없습니다.")
+    @Size(max = 20, message = "최대 20자까지 입력하실 수 있습니다.")
+    @Schema(description = "새로운 닉네임", example = "열공이", maxLength = 20)
     private String newNickname;
 
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdatePasswordRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdatePasswordRequest.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto.UserProfile;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -9,18 +10,22 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "유저 비밀번호 수정 요청 DTO")
 public class UpdatePasswordRequest {
 
-    @NotBlank
-    @Size(max = 70)
+    @NotBlank(message = "현재 비밀번호는 비어있을 수 없습니다.")
+    @Size(max = 70, message = "최대 70자까지 입력하실 수 있습니다.")
+    @Schema(description = "현재 사용 중인 비밀번호", example = "pass123", maxLength = 70)
     private String currentPassword;
 
-    @NotBlank
-    @Size(max = 70)
+    @NotBlank(message = "새로운 비밀번호는 비어있을 수 없습니다.")
+    @Size(max = 70, message = "최대 70자까지 입력하실 수 있습니다.")
+    @Schema(description = "새로운 비밀번호", example = "word456", maxLength = 70)
     private String newPassword;
 
-    @NotBlank
-    @Size(max = 70)
+    @NotBlank(message = "새로운 비밀번호는 비어있을 수 없습니다.")
+    @Size(max = 70, message = "최대 70자까지 입력하실 수 있습니다.")
+    @Schema(description = "새로운 비밀번호 확인", example = "word456", maxLength = 70)
     private String confirmNewPassword;
 
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateProfileImageRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UpdateProfileImageRequest.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto.UserProfile;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -9,10 +10,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "유저 프로필 이미지 수정 요청 DTO")
 public class UpdateProfileImageRequest {
 
-    @NotBlank
-    @Size(max = 1024)
+    @NotBlank(message = "새로운 프로필 이미지 주소는 비어있을 수 없습니다.")
+    @Size(max = 1024, message = "최대 1024자까지 입력하실 수 있습니다.")
+    @Schema(description = "새로운 프로필 이미지 주소", example = "https://newImage.com/profile.png", maxLength = 1024)
     private String newProfileImage;
 
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UserProfileResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UserProfileResponse.java
@@ -1,14 +1,26 @@
 package org.livestudy.dto.UserProfile;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "유저 프로필 응답 DTO")
 public class UserProfileResponse {
+
+    @Schema(description = "프로필 이미지 주소", example = "https://newImage.com/profile.png")
     private String profileImage;
+
+    @Schema(description = "유저 닉네임", example = "열공이")
     private String nickname;
+
+    @Schema(description = "유저 이메일", example = "new@example.com")
     private String email;
+
+    @Schema(description = "유저 장착 칭호", example = "NIGHT_OWL")
     private String selectedTitle;
+
+    @Schema(description = "누적 공부 시간", example = "23566")
     private Integer totalStudyTime;
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserStudyStatsResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserStudyStatsResponse.java
@@ -1,5 +1,6 @@
 package org.livestudy.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.livestudy.domain.user.UserStudyStat;
@@ -8,14 +9,28 @@ import java.time.LocalDate;
 
 @Getter
 @Builder
+@Schema(description = "유저 공부 데이터 응답 DTO")
 public class UserStudyStatsResponse {
 
+    @Schema(description = "유저 ID", example = "1L")
     private Long userId;
+
+    @Schema(description = "유저 닉네임", example = "열공이")
     private String nickname;
+
+    @Schema(description = "누적 공부 시간", example = "232334")
     private Integer totalStudyTime;
+
+    @Schema(description = "누적 자리 비움 시간", example = "5654")
     private Integer totalAwayTime;
+
+    @Schema(description = "누적 출석일 수", example = "123")
     private Integer totalAttendanceDays;
+
+    @Schema(description = "연속 출석일 수", example = "23")
     private Integer continueAttendanceDays;
+
+    @Schema(description = "마지막 출석일", example = "2025-08-01")
     private LocalDate lastAttendanceDate;
 
     public static UserStudyStatsResponse from(UserStudyStat userStudyStat) {

--- a/livestudy/src/main/java/org/livestudy/dto/report/ReportRequest.java
+++ b/livestudy/src/main/java/org/livestudy/dto/report/ReportRequest.java
@@ -1,15 +1,26 @@
 package org.livestudy.dto.report;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.livestudy.domain.report.ReportReason;
 
 @Getter
+@Schema(description = "신고 요청 정보 DTO")
 public class ReportRequest {
 
+    @Schema(description = "신고가 발생한 스터디룸 ID", example = "123", nullable = true)
     private Long roomId;
+
+    @Schema(description = "신고 당한 채팅 ID", example = "345")
     private Long chatId;
+
+    @Schema(description = "신고 당한 유저 ID", example = "56723")
     private Long reportedId;
+
+    @Schema(description = "신고 사유", example = "ABUSE")
     private ReportReason reason;
+
+    @Schema(description = "신고 사유 상세 설명", example = "해당 유저가 욕설을 하였습니다.", nullable = true)
     private String description;
 
     public ReportDto toCommand() {


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 Controller, DTO, ENUM 파일에 swagger 어노테이션을 추가합니다.
 1. Controller에는 @Tag, @Operation, @ApiResponse, @RequestBody를 통해 API 명세를 추합니다.
 2. ErrorResponse를 사용하여 API 응답 구조{errorCode, message}를 일치화합니다.
 3. DTO(Request, Response)에는 @Schema를 통해 데이터 구조를 명확하게 문서화합니다.
 4. EMUM에는 @Schema를 통해 데이터 구조를 명확하게 문서화합니다.
 
# 변경된 사항
 1. Controller에 swagger 어노테이션 추가
 2. DTO에 swagger 어노테이션 추가
 3. ENUM에 swagger 어노테이션 추가
 4. ErrorResponse DTO 생성