### PR TITLE
fix: 소셜 로그인 콜백 404 오류 해결

### DIFF
--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -26,7 +26,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.security.oauth2.client.registration.google.client-id=52046583081-ihlomiiibi4iggbs6bkicd768mfkg2jq.apps.googleusercontent.com
 spring.security.oauth2.client.registration.google.client-secret=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
 spring.security.oauth2.client.registration.google.scope=email,profile
-spring.security.oauth2.client.registration.google.redirect-uri=https://live-study.com/api/auth/oauth2/callback/google
+spring.security.oauth2.client.registration.google.redirect-uri=https://api.live-study.com/login/oauth2/code/google
 
 
 # Kakao OAuth2
@@ -34,7 +34,8 @@ spring.security.oauth2.client.registration.kakao.client-id=98521588a69d7a6c3945f
 spring.security.oauth2.client.registration.kakao.client-secret=dgHpBourPgbcbgJ1JKyaSqmqLI5p2syX
 spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.kakao.redirect-uri=https://live-study.com/api/auth/oauth2/callback/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.live-study.com/login/oauth2/code/kakao
+
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
 
 # Naver OAuth2
@@ -42,7 +43,7 @@ spring.security.oauth2.client.registration.naver.client-id=bOs4Dsopdpf7V6UC3B6n
 spring.security.oauth2.client.registration.naver.client-secret=X5BRSMACij
 spring.security.oauth2.client.registration.naver.scope=name,email,profile_image
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.naver.redirect-uri=https://live-study.com/api/auth/oauth2/callback/naver
+spring.security.oauth2.client.registration.naver.redirect-uri=https://api.live-study.com/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.client-name=Naver
 
 # OAuth2 Provider


### PR DESCRIPTION
 - 스프링 시큐리티 표준 OAuth2 콜백 경로로 redirect-uri 수정.
spring.security.oauth2.client.registration.google.redirect-uri=https://api.live-study.com/login/oauth2/code/google
spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.live-study.com/login/oauth2/code/kakao
spring.security.oauth2.client.registration.naver.redirect-uri=https://api.live-study.com/login/oauth2/code/naver
