### PR TITLE
fix: Docker 이미지 빌드 과정에서 COPY 단계 오류를 해결

### DIFF
--- a/livestudy/Dockerfile
+++ b/livestudy/Dockerfile
@@ -7,6 +7,6 @@ RUN gradle bootJar --no-daemon
 # Step 2: 실행
 FROM eclipse-temurin:21-jdk
 WORKDIR /app
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=builder /app/build/libs/app.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/livestudy/build.gradle
+++ b/livestudy/build.gradle
@@ -97,3 +97,7 @@ tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
 }
+
+bootJar {
+    archiveFileName = 'app.jar'
+}


### PR DESCRIPTION
 - Dockerfile의 COPY --from=builder /app/build/libs/*.jar app.jar → COPY --from=builder /app/build/libs/app.jar app.jar로 수정
 - build.gradle에 bootJar { archiveFileName = 'app.jar' } 추가