### PR TITLE
fix: 소셜 로그인 콜백 404 오류 해결

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -69,6 +69,8 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/api/auth/oauth2/authorize"))
+                        .redirectionEndpoint(redirection -> redirection
+                                .baseUri("https://api.live-study.com/login/oauth2/code/*"))
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)


### PR DESCRIPTION
 - SecurityConfig의 리디렉션 포인트 명시
 "https://api.live-study.com/login/oauth2/code/*"