### PR TITLE
Fix : CORS 설정 관련 변경사항

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -100,7 +100,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(Arrays.asList("https://localhost:5174", "https://live-study.com"));
+        configuration.setAllowedOrigins(Arrays.asList("https://localhost:5174", "http://localhost:5174", "https://live-study.com"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
@@ -26,7 +26,8 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     @Override // Client가 처음으로 WebSocket을 연결하는 Endpoint를 설정
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns("http://localhost:5174", "https://localhost:5174", // FE 개발용       // FE 개발용
+                        "https://live-study.com", "https://www.live-study.com")  // 배포용
                 .withSockJS();
     }
 


### PR DESCRIPTION
- FE 측에서 추가 요청사항 2가지가 들어와서 하기와 같이 변경 드립니다.

-. WebSocketConfiguration에서 registerStompEndPoints 메소드에서 setAllowedOriginPatterns()에 대해 기존 배포용 Config와 마찬가지로 로컬 개발 포트용, 배포용 도메인을 추가합니다. *는 삭제하오니 참고 부탁 드리겠습니다.

-. 로컬 개발 포트용에서 "https://" 뿐만 아니라 "http://" 도 추가를 드리오니, 이 점 참고 부탁 드리겠습니다.