### PR TITLE
Infra-fix : Caddy.yaml 변경

### DIFF
--- a/livestudy/livekit-server/livekit-config/caddy.yaml
+++ b/livestudy/livekit-server/livekit-config/caddy.yaml
@@ -45,6 +45,17 @@ apps:
               - host:
                   - api.live-study.com
             handle:
+              - handler: static_response
+                status_code: 204
+                headers:
+                  Access-Control-Allow-Origin:
+                    - "http://localhost:5174"
+                  Access-Control-Allow-Methods:
+                    - "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+                  Access-Control-Allow-Headers:
+                    - "Content-Type, Authorization"
+                  Access-Control-Allow-Credentials:
+                    - "true"
               - handler: reverse_proxy
                 upstreams:
                   - dial: localhost:8080


### PR DESCRIPTION
- 서버 로그에서 preflight 처리가 계속해서 안 되고 있는 점을 확인하여, CORS 설정 중 OPTIONS에 대해 Spring에서 처리하던 것을 CADDY에서 처리하는 것으로 바꾸었습니다.

- caddy.yaml의 설정이 바뀌었으니 이 점 참고 부탁 드립니다.