### PR TITLE
fix: 소셜 로그인 콜백 오류

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.livestudy.config;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.livestudy.oauth2.CustomOAuth2AuthorizationRequestRepository;
 import org.livestudy.oauth2.CustomOAuth2UserService;
 import org.livestudy.oauth2.OAuth2AuthenticationFailureHandler;
 import org.livestudy.oauth2.OAuth2AuthenticationSuccessHandler;
@@ -76,8 +77,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization
-                                .baseUri("/api/auth/oauth2/authorize"))
-                        .userInfoEndpoint(userInfo -> userInfo
+                                .baseUri("/api/auth/oauth2/authorize")
+                                .authorizationRequestRepository(new CustomOAuth2AuthorizationRequestRepository()))
+                .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureHandler(oAuth2AuthenticationFailureHandler))

--- a/livestudy/src/main/java/org/livestudy/oauth2/CookieUtils.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/CookieUtils.java
@@ -1,0 +1,55 @@
+package org.livestudy.oauth2;// CookieUtils.java
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<jakarta.servlet.http.Cookie> getCookie(HttpServletRequest request, String name) {
+        jakarta.servlet.http.Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (jakarta.servlet.http.Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        jakarta.servlet.http.Cookie cookie = new jakarta.servlet.http.Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        jakarta.servlet.http.Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (jakarta.servlet.http.Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(jakarta.servlet.http.Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+
+}

--- a/livestudy/src/main/java/org/livestudy/oauth2/CustomOAuth2AuthorizationRequestRepository.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/CustomOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,60 @@
+package org.livestudy.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+public class CustomOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    // 쿠키 이름
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    // 쿠키 만료 시간 (3분)
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Optional<jakarta.servlet.http.Cookie> cookie = CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        if (cookie.isPresent()) {
+            return deserialize(cookie.get(), OAuth2AuthorizationRequest.class);
+        }
+        return null;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        // 로그인 요청 정보가 있으면 쿠키에 저장
+        if (authorizationRequest != null) {
+            String serializedValue = serialize(authorizationRequest);
+            CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, serializedValue, COOKIE_EXPIRE_SECONDS);
+        } else {
+            // 없으면 쿠키 삭제
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        OAuth2AuthorizationRequest originalRequest = loadAuthorizationRequest(request);
+        removeAuthorizationRequestCookies(request, response);
+        return originalRequest;
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    }
+
+    // 직렬화
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    // 역직렬화
+    public static <T> T deserialize(jakarta.servlet.http.Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 소셜 로그인 시 `authorization_request_not_found` 에러가 발생하는 문제를 해결합니다.
 1. 세션 대신 쿠키 기반의 `CustomOAuth2AuthorizationRequestRepository`를 합니다.
 
# 변경된 사항
 1. SecurityConfig에 authorizationRequestRepository 추가