### PR TITLE
fix : security & log add

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -67,13 +67,13 @@ public class SecurityConfig {
                                 "/oauth2/**",
                                 "/api/debug/**",
                                 "/auth/**",
-                                "/api/user/**",
+                                "/rtc/**",
                                 "/api/study-rooms/**",
                                 "/login/oauth2/code/**",
                                 "/api/titles/**",
                                 "/api/timer/**"
                         ).permitAll()
-                        .requestMatchers("/api/livekit/**").authenticated()
+                        .requestMatchers("/api/user/**", "/api/livekit/**").authenticated()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization

--- a/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserProfileController.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.livestudy.dto.ErrorResponse;
 import org.livestudy.dto.UserProfile.*;
-import org.livestudy.dto.report.ReportRequest;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
 import org.livestudy.security.SecurityUser;
 import org.livestudy.service.ProfileService;
 import org.springframework.http.ResponseEntity;
@@ -42,6 +43,11 @@ public class UserProfileController {
     })
     public ResponseEntity<UserProfileResponse> getUserProfile(
             @AuthenticationPrincipal SecurityUser user) {
+
+        if (user == null) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
         Long userId = user.getUser().getId();
         log.info("마이페이지 - userId: {} 유저의 프로필 조회", userId);
 
@@ -69,6 +75,9 @@ public class UserProfileController {
     public ResponseEntity<Void> updateNickname(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdateNicknameRequest request) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         Long userId = user.getUser().getId();
 
@@ -98,6 +107,10 @@ public class UserProfileController {
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdateProfileImageRequest request) {
 
+        if (user == null) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
         Long userId = user.getUser().getId();
 
         profileService.updateProfileImage(userId, request);
@@ -126,6 +139,11 @@ public class UserProfileController {
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdateEmailRequest request) {
 
+        if (user == null) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+
         Long userId = user.getUser().getId();
 
         profileService.updateEmail(userId, request);
@@ -153,6 +171,10 @@ public class UserProfileController {
     public ResponseEntity<Void> updatePassword(
             @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody UpdatePasswordRequest request) {
+
+        if (user == null) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         Long userId = user.getUser().getId();
 

--- a/livestudy/src/main/java/org/livestudy/service/LiveKitTokenService.java
+++ b/livestudy/src/main/java/org/livestudy/service/LiveKitTokenService.java
@@ -45,6 +45,7 @@ public class LiveKitTokenService {
 
         token.addGrants(new RoomJoin(true));
         token.addGrants(new RoomName(roomId));
+        token.addGrants(new RoomCreate(true));
         token.addGrants(new CanPublish(true));
         token.addGrants(new CanSubscribe(true));
         token.addGrants(new CanPublishData(true));


### PR DESCRIPTION
- 현재 토큰 발급 후 입장 단계에서 401 Unauthorized가 되고 있는 점이 확인되어있고, /rtc로 주소를 주고 있는 와중에 인증 권한이 아무것도 없음을 발견하여 permitAll()로 먼저 변경드리고자 합니다.

- 또한, 현재 사용자 페이지 조회, 갱신 등 모두 401 UnAuthorized로 되어 있는데, 이 부분은 api/user/**가 permitall로 되어 익명 객체 혹은 아무것도 없이 전달이 되어 NullPointerException이 발생하고 있는 것 같습니다. 실제로 user == null로 인하여 Exception이 발생 중이오니, 이 부분은 .authenticated()로 변경드립니다. 이후에는 exception 발생 로직만 추가하였습니다.

- Token 관련하여 createRoom 로직이 있기에, RoomCreate(true)가 되게끔 권한을 주는 로직을 추가하였습니다.