### PR TITLE
fix: 소셜 로그인 콜백 오류 해결

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -78,7 +78,6 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization
-                                .baseUri("/api/auth/oauth2/authorize")
                                 .authorizationRequestRepository(new CustomOAuth2AuthorizationRequestRepository()))
                 .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService))


### PR DESCRIPTION
 - 소셜로그인의 authorizationEndpoint.baseUri("/api/auth/oauth2/authorize") 삭제하여 기본 URL 사용