### PR TITLE
fix: 소셜 로그인 invalid client 오류 해결

### DIFF
--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -35,6 +35,8 @@ spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.live-study.com/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.client-authentication-method=post
+
 
 # Naver OAuth2
 spring.security.oauth2.client.registration.naver.client-id=bOs4Dsopdpf7V6UC3B6n
@@ -43,7 +45,7 @@ spring.security.oauth2.client.registration.naver.scope=name,email,profile_image
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.redirect-uri=https://api.live-study.com/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.client-name=naver
-
+spring.security.oauth2.client.registration.naver.client-authentication-method=post
 
 # OAuth2 Provider
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth


### PR DESCRIPTION
 - 카카오, 네이버 로그인 시 토큰을 POST 전달