### PR TITLE
feature: 마이 페이지 수정

### DIFF
--- a/livestudy/src/main/java/org/livestudy/dto/UserProfile/UserProfileResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserProfile/UserProfileResponse.java
@@ -23,4 +23,10 @@ public class UserProfileResponse {
 
     @Schema(description = "누적 공부 시간", example = "23566")
     private Integer totalStudyTime;
+
+    @Schema(description = "누적 출석일", example = "121")
+    private Integer totalAttendanceDays;
+
+    @Schema(description = "연속 출석일", example = "23")
+    private Integer continueAttendanceDays;
 }

--- a/livestudy/src/main/java/org/livestudy/service/ProfileServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/ProfileServiceImpl.java
@@ -45,6 +45,10 @@ public class ProfileServiceImpl implements ProfileService{
                 .selectedTitle(selectedTitleName)
                 .totalStudyTime(userStudyStat != null ?
                         userStudyStat.getTotalStudyTime() : 0)
+                .totalAttendanceDays(userStudyStat != null ?
+                        userStudyStat.getTotalAttendanceDays() : 0)
+                .continueAttendanceDays(userStudyStat != null ?
+                        userStudyStat.getContinueAttendanceDays() : 0)
                 .build();
     }
 


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 유저의 마이페이지에 들어가는 데이터에 누적 출석일, 연속 출석일을 포함합니다.
 1. 유저의 마이페이지에는 '프로필 이미지', '닉네임', '이메일 주소', '누적 공부 시간', '칭호'에 더해 '누적 출석일', 연속 출석일'을 조회할 수 있습니다. 
 
# 변경된 사항
 1. UserProfileResponse.java
    - 누적 출석일(totalAttendanceDays), 연속 출석일(continueAttendanceDays) 추가.
 3. ProfileServiceImpl.java
    - getUserProfile 메서드의 UserProfileResponse 빌더에 누적 출석일, 연속 출석일 추가.