### PR TITLE
add : user-titleapi

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/TitleController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/TitleController.java
@@ -3,6 +3,9 @@ package org.livestudy.controller;
 import io.swagger.v3.oas.annotations.Operation;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -56,5 +59,24 @@ public class TitleController {
         UserTitleResponse response = titleService.equipTitle(userId, titleId);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/{userId}/list")
+    @Operation(
+            summary = "유저 칭호 목록 조회",
+            description = "특정 유저가 획득한 모든 칭호 목록을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "칭호 목록 조회 성공",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = UserTitleResponse.class)))
+                    ),
+                    @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+            }
+    )
+    public ResponseEntity<List<UserTitleResponse>> getUserTitles(
+            @Parameter(description = "조회할 유저의 ID", required = true)
+            @PathVariable Long userId) {
+        List<UserTitleResponse> titles = titleService.getUserTitles(userId);
+        return ResponseEntity.ok(titles);
+    }
+
 
 }

--- a/livestudy/src/main/java/org/livestudy/dto/UserTitleResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserTitleResponse.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.livestudy.domain.title.UserTitle;
 
 @Getter
 @Builder
@@ -24,4 +25,14 @@ public class UserTitleResponse {
     @Schema(description = "대표 칭호 여부")
     @JsonProperty("isRepresentative")
     private boolean isRepresentative;
+
+    public static UserTitleResponse from(UserTitle userTitle) {
+        return new UserTitleResponse(
+                userTitle.getTitle().getId(),
+                userTitle.getTitle().getName(),
+                userTitle.getTitle().getDescription(),
+                userTitle.isEquipped()
+        );
+
+    }
 }

--- a/livestudy/src/main/java/org/livestudy/repository/UserTitleRepository.java
+++ b/livestudy/src/main/java/org/livestudy/repository/UserTitleRepository.java
@@ -17,4 +17,5 @@ public interface UserTitleRepository extends JpaRepository<UserTitle, Long> {
     List<UserTitle> findAllByUserAndIsEquippedTrue(User user);
 
 
+    List<UserTitle> findAllByUser(User user);
 }

--- a/livestudy/src/main/java/org/livestudy/service/ProfileServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/ProfileServiceImpl.java
@@ -99,26 +99,26 @@ public class ProfileServiceImpl implements ProfileService{
     @Transactional
     public void updateEmail(Long userId, UpdateEmailRequest request) {
 
-        // User 엔티티 조회
+        // 1. 유저 조회
         User user = getUserById(userId);
         String newEmail = request.getNewEmail();
 
-        // 현재 이메일과 동일한지 체크
+        // 2. 현재 이메일과 동일한 경우
         if (user.getEmail().equals(newEmail)) {
             log.error("userId: {} 유저의 이메일 변경이 실패하였습니다. 사유: SAME_EMAIL", userId);
             throw new CustomException(ErrorCode.SAME_EMAIL);
         }
-        // 이미 사용 중인 이메일인지 체크
+
+        // 3. 이미 사용 중인 이메일인지 체크
         if (userRepo.existsByEmail(newEmail)) {
             log.error("userId: {} 유저의 이메일 변경이 실패하였습니다. 사유: DUPLICATE_EMAIL", userId);
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-
+        // 4. 이메일 업데이트 및 저장
         user.updateEmail(newEmail);
         userRepo.save(user);
         log.info("userId: {} 유저의 이메일이 '{}'로 변경되었습니다.", userId, newEmail);
-
     }
 
     @Override

--- a/livestudy/src/main/java/org/livestudy/service/TitleService.java
+++ b/livestudy/src/main/java/org/livestudy/service/TitleService.java
@@ -11,4 +11,6 @@ public interface TitleService {
     List<Title> evaluateAndGrantTitles(Long userId);
 
     UserTitleResponse equipTitle(Long userId, Long titleId);
+
+    List<UserTitleResponse> getUserTitles(Long userId);
 }

--- a/livestudy/src/main/java/org/livestudy/service/TitleServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/TitleServiceImpl.java
@@ -86,4 +86,17 @@ public class TitleServiceImpl implements TitleService {
         userRepository.save(user);
         return null;
     }
+
+    @Override
+    public List<UserTitleResponse> getUserTitles(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<UserTitle> userTitles = userTitleRepository.findAllByUser(user);
+
+        return userTitles.stream()
+                .map(UserTitleResponse::from)
+                .toList();
+    }
+
 }


### PR DESCRIPTION
-. 마이 페이지에서 칭호를 조회하는 api를 작성하여 추가드립니다.

-. DTO UserTitleResponse에서 정보 객체를 생성하는 from이라는 static method를 작성하였습니다.

-. UserTitleRepository에서 칭호 조회를 위한 findAllByUser(User user);를 작성하였습니다.

-. Service 로직에서 Title을 조회할 때 UserTitleResponse DTO를 토대로 List형으로 조회할 수 있게 로직을 했습니다.