### PR TITLE
fix: 쿠키 설정 변경 및 REST API 주석 처리

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/AuthController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/AuthController.java
@@ -74,10 +74,10 @@ public class  AuthController {
         return ResponseEntity.ok(response);
     }
 
-    // OAuth2 로그인 URL 제공
+/*    // OAuth2 로그인 URL 제공
     @GetMapping("/oauth2/url/{provider}")
     public ResponseEntity<Map<String, String>> getOAuth2LoginUrl(@PathVariable String provider) {
         String authUrl = String.format("/api/auth/oauth2/authorize/%s", provider.toLowerCase());
         return ResponseEntity.ok(Map.of("authUrl", authUrl));
-    }
+    }*/
 }

--- a/livestudy/src/main/java/org/livestudy/oauth2/CookieUtils.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/CookieUtils.java
@@ -26,6 +26,8 @@ public class CookieUtils {
         cookie.setHttpOnly(true);
         cookie.setMaxAge(maxAge);
         cookie.setDomain(".live-study.com");
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
         response.addCookie(cookie);
     }
 


### PR DESCRIPTION
 - live-study.com 과 api.live-study.com 으로 도메인이 이동해도 쿠키 저장합니다.
 - GET /oauth2/url/{provider} API를 주석처리하여 사용하지 않습니다.