### PR TITLE
Refactoring : livekit-token

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/LiveKitTokenController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/LiveKitTokenController.java
@@ -15,7 +15,7 @@ import org.livestudy.exception.CustomException;
 import org.livestudy.exception.ErrorCode;
 import org.livestudy.repository.redis.RoomRedisRepository;
 import org.livestudy.security.SecurityUser;
-import org.livestudy.service.LiveKitTokenService;
+import org.livestudy.service.livekit.LiveKitTokenService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;

--- a/livestudy/src/main/java/org/livestudy/controller/StudyRoomController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/StudyRoomController.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.livestudy.dto.EnterStudyRoomResponse;
+import org.livestudy.service.livekit.LiveKitJoinService;
 import org.livestudy.service.StudyRoomService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "스터디룸 API", description = "스터디룸 입장/퇴장 API")
 public class StudyRoomController {
 
+    private final LiveKitJoinService liveKitJoinService;
     private final StudyRoomService studyRoomService;
 
     @PostMapping("/enter")
@@ -31,11 +34,12 @@ public class StudyRoomController {
             @ApiResponse(responseCode = "200", description = "입장 성공, 방 ID 반환"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    public ResponseEntity<String> enterRoom(
+    public ResponseEntity<EnterStudyRoomResponse> enterRoom(
             @Parameter(description = "사용자 ID", example = "user123")
             @RequestParam String userId){
-        String roomId = String.valueOf(studyRoomService.enterRoom(userId));
-        return ResponseEntity.ok(roomId);
+        EnterStudyRoomResponse response = liveKitJoinService.joinRoomAndGetToken(userId);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/leave")

--- a/livestudy/src/main/java/org/livestudy/dto/EnterStudyRoomResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/EnterStudyRoomResponse.java
@@ -1,0 +1,5 @@
+package org.livestudy.dto;
+
+
+
+public record EnterStudyRoomResponse (String roomId, String accessToken){ }

--- a/livestudy/src/main/java/org/livestudy/service/StudyRoomService.java
+++ b/livestudy/src/main/java/org/livestudy/service/StudyRoomService.java
@@ -7,4 +7,5 @@ public interface StudyRoomService {
     void leaveRoom(String userId);  // 퇴장
 
     String createRoom(int capacity); // 방 생성
+
 }

--- a/livestudy/src/main/java/org/livestudy/service/StudyRoomServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/StudyRoomServiceImpl.java
@@ -126,4 +126,5 @@ public class StudyRoomServiceImpl implements StudyRoomService {
 
         return saved.getId().toString();
     }
+
 }

--- a/livestudy/src/main/java/org/livestudy/service/livekit/LiveKitTokenService.java
+++ b/livestudy/src/main/java/org/livestudy/service/livekit/LiveKitTokenService.java
@@ -1,4 +1,4 @@
-package org.livestudy.service;
+package org.livestudy.service.livekit;
 
 import io.livekit.server.*;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,7 @@ public class LiveKitTokenService {
 
     private static final Logger log = LoggerFactory.getLogger(LiveKitTokenService.class);
 
+
     @Value("${livekit.api-key}")
     private String apiKey;
 
@@ -23,20 +24,22 @@ public class LiveKitTokenService {
     private String apiSecret;
 
     public LiveKitTokenService(
-             String apiKey,
-             String apiSecret) {
+            String apiKey,
+            String apiSecret) {
         this.apiKey = apiKey;
         this.apiSecret = apiSecret;
     }
+
 
     public String generateToken(String userId, String roomId){
 
         if(userId == null) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
-        } else if(roomId == null) {
-            throw new CustomException(ErrorCode.ROOM_NOT_FOUND);
         }
 
+        if(roomId == null) {
+            throw new CustomException(ErrorCode.ROOM_NOT_FOUND);
+        }
 
         // 토큰 생성
         AccessToken token = new AccessToken(apiKey, apiSecret);

--- a/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
@@ -27,7 +27,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("http://localhost:5174", "https://localhost:5174", // FE 개발용
-                        "https://live-study.com", "https://www.live-study.com")  // 배포용
+                        "https://live-study.com", "https://www.live-study.com", "https://api.live-study.com")  // 배포용
                 .withSockJS();
     }
 

--- a/livestudy/src/test/java/org/livestudy/service/LiveKitJoinTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/LiveKitJoinTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.livestudy.exception.CustomException;
 import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.redis.RoomRedisRepository;
 import org.livestudy.security.jwt.JwtTokenProvider;
+import org.livestudy.service.livekit.LiveKitTokenService;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -30,6 +32,8 @@ public class LiveKitJoinTest {
     private LiveKitTokenService liveKitTokenService;
 
     private JwtTokenProvider jwtTokenProvider;
+
+    private RoomRedisRepository roomRedisRepository;
 
     @BeforeEach
     void setUp(){


### PR DESCRIPTION
- 발급하기 전에 Redis를 조회하여 방 ID를 배정받는 로직으로 개선했습니다.

- 또한, Test 코드 작성하여 발급 -> 입장 퇴장까지 진행했습니다.

- 퇴장 로직의 변경사항은 없으며, 입장 로직과 LivekitToken 발급 로직만 바꾸었으니 참고 부탁 드리겠습니다.