### PR TITLE
fix: 인증되지 않은 사용자에 대한 Exception 문제 해결

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
                                 "/api/titles/**",
                                 "/api/timer/**"
                         ).permitAll()
-                        .requestMatchers("/api/user/**", "/api/livekit/**").authenticated()
+                        .requestMatchers("/api/user/**", "/api/livekit/**", "/api/user/stat/**").authenticated()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization

--- a/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/UserStatController.java
@@ -15,6 +15,8 @@ import org.livestudy.dto.DailyRecordResponse;
 import org.livestudy.dto.TodayStudyTimeResponse;
 import org.livestudy.dto.ErrorResponse;
 import org.livestudy.dto.UserStudyStatsResponse;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
 import org.livestudy.security.SecurityUser;
 import org.livestudy.service.UserStudyStatService;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -54,6 +56,11 @@ public class UserStatController {
     public ResponseEntity<UserStudyStatsResponse> getUserNormalStats(
             @AuthenticationPrincipal SecurityUser user) {
 
+        if (user == null || user.getUser() == null) {
+            log.error("인증되지 않은 사용자가 '/api/user/stat/normal' 에 접근을 시도했습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long userId = user.getUser().getId();
 
         log.info("통계 페이지 - userId: {} 유저의 공부 정보 조회", userId);
@@ -84,6 +91,11 @@ public class UserStatController {
             @AuthenticationPrincipal SecurityUser user,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        if (user == null || user.getUser() == null) {
+            log.error("인증되지 않은 사용자가 '/api/user/stat/daily-focus' 에 접근을 시도했습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
 
         Long userId = user.getUser().getId();
 
@@ -119,6 +131,11 @@ public class UserStatController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
+        if (user == null || user.getUser() == null) {
+            log.error("인증되지 않은 사용자가 '/api/user/stat/average-focus-ratio' 에 접근을 시도했습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long userId = user.getUser().getId();
 
         LocalDate end = (endDate != null) ? endDate : LocalDate.now();
@@ -142,6 +159,11 @@ public class UserStatController {
     public ResponseEntity<TodayStudyTimeResponse> getTodayStudyTime(
             @AuthenticationPrincipal SecurityUser user) {
 
+        if (user == null || user.getUser() == null) {
+            log.error("인증되지 않은 사용자가 '/api/user/stat/today-study-time' 에 접근을 시도했습니다.");
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        
         Long userId = user.getUser().getId();
         log.info("userId: {} 유저의 오늘 공부 시간 조회", userId);
 


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 UserStatController에서 NullPointerException이 발생하는 것을 해결합니다.
 1. UserStatController의 @AuthenticationPrincipal를 통해 전달되는 user가 null일 경우, CustomException(ErrorCode.UNAUTHORIZED)을 전달합니다.
 2. UserStatController에 접근하기 전에 인증되지 않은 요청이 차단됩니다.
 
# 변경된 사항
 1. UserStatController의 모든 메서드에 CustomException(ErrorCode.UNAUTHORIZED) 및 log.error 추가.
 2. SecurityConfig의 authenticated() 설정에 `/api/user/stat/**` 추가.
