### PR TITLE
Security/token-twoways-Delcastin

### DIFF
--- a/livestudy/src/main/java/org/livestudy/component/LiveKitTokenVerifier.java
+++ b/livestudy/src/main/java/org/livestudy/component/LiveKitTokenVerifier.java
@@ -1,0 +1,56 @@
+package org.livestudy.component;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class LiveKitTokenVerifier {
+
+    private final JwtParser jwtParser;
+
+
+    public LiveKitTokenVerifier(@Value("${livekit.api-secret}") String apiSecret) {
+        SecretKey key = Keys.hmacShaKeyFor(apiSecret.getBytes(StandardCharsets.UTF_8));
+        this.jwtParser = Jwts.parser()
+                .verifyWith(key)
+                .build();
+    }
+
+    public DecodedLiveKitToken decode(String token) throws Exception {
+        try {
+            Jwt<?, ?> jwt = jwtParser.parse(token);
+            Claims claims = (Claims) jwt.getPayload();
+
+            String identity = claims.getSubject();  // sub 필드
+            Map<String, Object> videoClaim = claims.get("video", Map.class);
+            String room = videoClaim != null ? (String) videoClaim.get("room") : null;
+
+            return new DecodedLiveKitToken(identity, room);
+        } catch (JwtException e) {
+            log.error("Failed to parse or validate LiveKit token: {}", token, e);
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (Exception e) {
+            log.error("Unexpected error while decoding LiveKit token: {}", token, e);
+            throw new InvalidTokenException("Error decoding LiveKit token", e);
+        }
+    }
+
+    public record DecodedLiveKitToken(String identity, String roomId) {}
+
+    public static class InvalidTokenException extends RuntimeException {
+        public InvalidTokenException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+}

--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.livestudy.oauth2.CustomOAuth2UserService;
 import org.livestudy.oauth2.OAuth2AuthenticationFailureHandler;
 import org.livestudy.oauth2.OAuth2AuthenticationSuccessHandler;
 import org.livestudy.security.jwt.JwtAuthenticationFilter;
+import org.livestudy.websocket.security.LiveKitTokenAuthenticationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -35,6 +36,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final LiveKitTokenAuthenticationFilter liveKitTokenAuthenticationFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
@@ -67,6 +69,9 @@ public class SecurityConfig {
                                 "/oauth2/**",
                                 "/api/debug/**",
                                 "/auth/**",
+                                "/rtc/**",
+                                "/rtc",
+                                "/favicon.ico",
                                 "/api/study-rooms/**",
                                 "/login/oauth2/code/**",
                                 "/api/titles/**",
@@ -81,7 +86,9 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureHandler(oAuth2AuthenticationFailureHandler))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(liveKitTokenAuthenticationFilter, JwtAuthenticationFilter.class); //????????
+
 
         httpSecurity
                 .exceptionHandling(ex -> ex

--- a/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
+++ b/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     FORBIDDEN("A002", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
     EXPIRED_TOKEN("A003", "토큰이 만료되었습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS),
     REDIS_CONNECTION_FAILED("A004", "Redis 서버가 끊겼습니다.", HttpStatus.PRECONDITION_FAILED),
+    INVALID_TOKEN("A005", "잘못된 토큰입니다.", HttpStatus.UNAUTHORIZED),
 
     // WebSocket 관련 에러
     USER_ID_MISMATCH("W001", "userId가 일치하지 않습니다.", HttpStatus.FORBIDDEN),

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
@@ -28,11 +28,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = resolveToken(request);
 
-//        String path = request.getRequestURI();
-//        if(path.startsWith("/ws")){
-//                 filterChain.doFilter(request, response);
-//                 return;
-//             }
+        String path = request.getRequestURI();
+        if(path.startsWith("/rtc")){
+                 filterChain.doFilter(request, response);
+                 return;
+             }
 
         if(token != null && jwtTokenProvider.validateToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
@@ -50,20 +50,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
 
-        String accessToken = request.getParameter("access_token");
-        if(accessToken != null && !accessToken.isEmpty()) {
-            return accessToken;
-        }
-
         return null;
     }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        // WebSocket 연결할 때 필터를 실행하지 않음
-        if(path.startsWith("/ws") || path.startsWith("/rtc"))
-            return true;
         // OAuth2 인증 관련 경로와 로그인/회원가입 API 경로에서는 필터를 실행하지 않음
         return path.startsWith("/oauth2/") || path.startsWith("/api/auth/");
     }

--- a/livestudy/src/main/java/org/livestudy/service/livekit/LiveKitJoinService.java
+++ b/livestudy/src/main/java/org/livestudy/service/livekit/LiveKitJoinService.java
@@ -1,0 +1,27 @@
+package org.livestudy.service.livekit;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.livestudy.dto.EnterStudyRoomResponse;
+import org.livestudy.service.StudyRoomService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LiveKitJoinService {
+
+    private final StudyRoomService studyRoomService;
+    private final LiveKitTokenService liveKitTokenService;
+
+    @Transactional
+    public EnterStudyRoomResponse joinRoomAndGetToken(String userId) {
+        // 1. Redis + DB에서 방 배정하기
+        Long roomId = studyRoomService.enterRoom(userId);
+
+        String token = liveKitTokenService.generateToken(userId, String.valueOf(roomId));
+
+        // 2. Livekit JWT 토큰 발급
+        return new EnterStudyRoomResponse(String.valueOf(roomId), token);
+
+    }
+}

--- a/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
@@ -28,7 +28,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
 
     @Override // Client가 처음으로 WebSocket을 연결하는 Endpoint를 설정
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws")
+        registry.addEndpoint("/rtc")
                 .setAllowedOriginPatterns("http://localhost:5174", "https://localhost:5174", // FE 개발용
                         "https://live-study.com", "https://www.live-study.com", "https://api.live-study.com")  // 배포용
                 .addInterceptors(jwtHandshakeInterceptor) // 주소 도달 시 입장용 토큰에 대하여 인증을 진행한다!

--- a/livestudy/src/main/java/org/livestudy/websocket/security/LiveKitTokenAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/security/LiveKitTokenAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package org.livestudy.websocket.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.livestudy.component.LiveKitTokenVerifier;
+import org.livestudy.security.jwt.JwtTokenProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class LiveKitTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final LiveKitTokenVerifier liveKitTokenVerifier;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LiveKitTokenAuthenticationFilter(LiveKitTokenVerifier liveKitTokenVerifier, JwtTokenProvider jwtTokenProvider) {
+        this.liveKitTokenVerifier = liveKitTokenVerifier;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                 FilterChain filterChain) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+        log.debug("LiveKitTokenAuthenticationFilter - 요청 경로: {}", path);
+
+        if (!path.startsWith("/rtc")) {
+            log.debug("LiveKitTokenAuthenticationFilter - /rtc 경로가 아니므로 필터 패스");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = request.getParameter("access_token");
+        log.debug("LiveKitTokenAuthenticationFilter - access_token: {}", accessToken != null ? "[존재]" : "[없음]");
+
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("LiveKitTokenAuthenticationFilter - 인증 성공, SecurityContext에 저장");
+        } else {
+            log.warn("LiveKitTokenAuthenticationFilter - 인증 실패, 401 Unauthorized 응답");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/livestudy/src/test/java/org/livestudy/service/LiveKitTokenAuthenticationFilterTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/LiveKitTokenAuthenticationFilterTest.java
@@ -1,0 +1,91 @@
+package org.livestudy.service;
+
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.livestudy.component.LiveKitTokenVerifier;
+import org.livestudy.security.jwt.JwtTokenProvider;
+import org.livestudy.websocket.security.LiveKitTokenAuthenticationFilter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class LiveKitTokenAuthenticationFilterTest {
+
+    @Mock
+    LiveKitTokenVerifier liveKitTokenVerifier;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    FilterChain filterChain;
+
+    @InjectMocks
+    LiveKitTokenAuthenticationFilter filter;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+
+    @Test
+    void givenRtcPathAndValidToken_setsAuthentication() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/rtc/enter");
+        request.setParameter("access_token", "valid-token");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtTokenProvider.validateToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.getAuthentication("valid-token")).thenReturn(mock(Authentication.class));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(jwtTokenProvider).validateToken("valid-token");
+        verify(jwtTokenProvider).getAuthentication("valid-token");
+        verify(filterChain).doFilter(request, response);
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void givenRtcPathAndInvalidToken_returns401() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/rtc/enter");
+        request.setParameter("access_token", "invalid-token");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtTokenProvider.validateToken("invalid-token")).thenReturn(false);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(401, response.getStatus());
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void givenNonRtcPath_filterBypasses() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/ws/somepath");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}


### PR DESCRIPTION
- 로그인 시 사용되는 Header와 Livekit 입장 시 사용되는 Header가 다른 점을 인지하여 그 Token은 다르게 받을 수 있도록 조치를 취했습니다.

- 일단은 Token 로직만 바꾸었고, 저번에 Merge하여 있는 방 입장 관련된 부분들, RoomJoinService, LivekitTokenVerifier는 바뀌지 않았사오니, 참고 부탁 드리겠습니다.