### PR TITLE
feature: 소셜로그인에 필요한 scope 조정

### DIFF
--- a/livestudy/src/main/java/org/livestudy/domain/user/User.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/User.java
@@ -8,6 +8,8 @@ import org.livestudy.domain.title.UserTitle;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @Setter
@@ -86,6 +88,12 @@ public class User extends BaseEntity {
                                 String nickname,
                                 String profileImage,
                                 SocialProvider socialProvider) {
+
+        //이메일이 없을 경우 임의의 이메일 생성
+        if (email == null) {
+            email = socialProvider.name() + "_" + UUID.randomUUID().toString() +"@livestudy.com";
+        }
+
         return User.builder()
                 .email(email)
                 .nickname(nickname)

--- a/livestudy/src/main/java/org/livestudy/oauth2/CustomOAuth2UserService.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/CustomOAuth2UserService.java
@@ -38,10 +38,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oauth2User.getAttributes());
 
-        if (!StringUtils.hasText(oAuth2UserInfo.getEmail())) {
-            throw new CustomException(ErrorCode.INVALID_INPUT);
-        }
-
         Optional<User> userOptional = userRepository.findByEmail(oAuth2UserInfo.getEmail());
         User user;
 

--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -25,23 +25,22 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 # Google OAuth2
 spring.security.oauth2.client.registration.google.client-id=52046583081-ihlomiiibi4iggbs6bkicd768mfkg2jq.apps.googleusercontent.com
 spring.security.oauth2.client.registration.google.client-secret=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
-spring.security.oauth2.client.registration.google.scope=email,profile
+spring.security.oauth2.client.registration.google.scope=openid,profile,email
 spring.security.oauth2.client.registration.google.redirect-uri=https://api.live-study.com/login/oauth2/code/google
 
 # Kakao OAuth2
 spring.security.oauth2.client.registration.kakao.client-id=98521588a69d7a6c3945fb4307caebad
 spring.security.oauth2.client.registration.kakao.client-secret=dgHpBourPgbcbgJ1JKyaSqmqLI5p2syX
-spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.live-study.com/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
 spring.security.oauth2.client.registration.kakao.client-authentication-method=post
 
-
 # Naver OAuth2
 spring.security.oauth2.client.registration.naver.client-id=bOs4Dsopdpf7V6UC3B6n
 spring.security.oauth2.client.registration.naver.client-secret=X5BRSMACij
-spring.security.oauth2.client.registration.naver.scope=name,email,profile_image
+spring.security.oauth2.client.registration.naver.scope=nickname,profile_image
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.redirect-uri=https://api.live-study.com/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.client-name=naver
@@ -51,7 +50,7 @@ spring.security.oauth2.client.registration.naver.client-authentication-method=po
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth
 spring.security.oauth2.client.provider.google.token-uri=https://www.googleapis.com/oauth2/v4/token
 spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v2/userinfo
-spring.security.oauth2.client.provider.google.user-name-attribute=id
+spring.security.oauth2.client.provider.google.user-name-attribute=sub
 
 spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
@@ -61,7 +60,7 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
-spring.security.oauth2.client.provider.naver.user-name-attribute=response
+spring.security.oauth2.client.provider.naver.user-name-attribute=response.id
 
 # Frontend URL (CORS ? ??????)
 app.frontend.url=https://live-study.com


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 소셜로그인 시 가져오는 데이터(scope)를 지정합니다.
 1. 소셜로그인 구글(openid,profile,email), 카카오(profile_nickname,profile_image), 네이버(nickname,profile_image)를 scope로 설정합니다.
 2. email이 없을 시, 자동으로 임의의 email을 생성하여 회원가입을 진행합니다.
 
# 변경된 사항
 1. 구글(openid,profile,email), 카카오(profile_nickname,profile_image), 네이버(nickname,profile_image)를 scope 값으로 수정.
 2. user.java의 ofSocial 메서드에서 이메일 생성 로직 추가.
 3. 회원가입 과정에서 이메일이 없을 경우 에러 예외 던지는 로직 제거.
