### PR TITLE
feature: IllegalArgumentException, ClassCastException 오류 해결

### DIFF
--- a/livestudy/livekit-server/livekit-config/docker-compose.yaml
+++ b/livestudy/livekit-server/livekit-config/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
     build:
       context: ../../   # Dockerfile과 build.gradle이 있는 폴더
     network_mode: "host"
-    environment:
-      - SPRING_PROFILES_ACTIVE=prod
     restart: unless-stopped
     depends_on:
       - redis

--- a/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
+++ b/livestudy/src/main/java/org/livestudy/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     SAME_EMAIL("U016", "현재 사용 중인 이메일로는 변경하실 수 없습니다.", HttpStatus.BAD_REQUEST),
     SAME_PASSWORD("U017", "현재 사용 중인 비밀번호로는 변경하실 수 없습니다.", HttpStatus.BAD_REQUEST),
     IMAGE_UPLOAD_FAILED("U018", "이미지 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNSUPPORTED_PROVIDER("U019", "지원하지 않는 소셜 로그인 입니다.", HttpStatus.BAD_REQUEST),
 
 
     // Track 관련 에러

--- a/livestudy/src/main/java/org/livestudy/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -4,10 +4,18 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.livestudy.domain.user.SocialProvider;
+import org.livestudy.domain.user.User;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
 import org.livestudy.security.SecurityUser;
 import org.livestudy.security.jwt.JwtTokenProvider;
+import org.livestudy.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -20,6 +28,7 @@ import java.io.IOException;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
 
     @Value("${app.frontend.url}")
     private String frontendUrl;
@@ -50,18 +59,46 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         }
     }
 
-    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request,
+                                        HttpServletResponse response,
                                         Authentication authentication) {
 
-        // SecurityUser로 직접 캐스팅 (이미 OAuth2User도 구현하고 있음)
-        SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
+        // ① provider·attribute 추출
+        OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+        String registrationId = oauthToken.getAuthorizedClientRegistrationId();   // "google" | "kakao" | "naver"
 
-        // JWT 토큰 생성 (기존 방식 그대로 사용)
-        String token = jwtTokenProvider.generateToken(authentication);
-        log.debug("Generated JWT token for user: " + securityUser.getUsername());
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(
+                registrationId,
+                ((OAuth2User) authentication.getPrincipal()).getAttributes());
 
+        if (userInfo == null) {
+            throw new CustomException(ErrorCode.UNSUPPORTED_PROVIDER);
+        }
+
+        // ② DB 조회·신규 생성
+        SocialProvider provider = SocialProvider.valueOf(registrationId.toUpperCase());
+        User member = userService.findOrCreateSocialUser(
+                userInfo.getEmail(),
+                userInfo.getName(),
+                provider
+        );
+
+        // ③ SecurityUser로 래핑
+        SecurityUser securityUser = new SecurityUser(member);
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(securityUser,
+                        null,
+                        securityUser.getAuthorities());
+
+        // ④ JWT 발급
+        String token = jwtTokenProvider.generateToken(authToken);
+
+        // ⑤ 프론트로 redirect
         return UriComponentsBuilder.fromUriString(frontendUrl + "/auth/success")
                 .queryParam("token", token)
-                .build().toUriString();
+                .queryParam("isNew", member.isNewUser())
+                .build()
+                .toUriString();
     }
 }

--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -35,7 +35,7 @@ spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.live-study.com/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
-spring.security.oauth2.client.registration.kakao.client-authentication-method=post
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
 
 # Naver OAuth2
 spring.security.oauth2.client.registration.naver.client-id=bOs4Dsopdpf7V6UC3B6n
@@ -44,7 +44,7 @@ spring.security.oauth2.client.registration.naver.scope=nickname,profile_image
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.redirect-uri=https://api.live-study.com/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.client-name=naver
-spring.security.oauth2.client.registration.naver.client-authentication-method=post
+spring.security.oauth2.client.registration.naver.client-authentication-method=client_secret_post
 
 # OAuth2 Provider
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 IllegalArgumentException, ClassCastException 오류를 해결합니다.
 1. 카카오, 네이버 로그인 시, client-authentication-method=client_secret_post로 접근합니다.(Spring Security 6에서 변경됨)
 2. 소셜 로그인 시, determineTargetUrl를 통해 소셜 측에서 제공하는 정보를 live-study.com 서비스의 정보 양식에 맞게 변환하여 저장하고, JWT 토큰을 발급받아 프론트엔드로 리다이렉트 합니다.
 
# 변경된 사항
 1. application.properties의 client-authentication-method=client_secret_post 수정.
 2. OAuth2AuthenticationSuccessHandler의 determineTargetUrl 로직 변경.
 3. ErrorCode에 UNSUPPORTED_PROVIDER 추가.
