### PR TITLE
feat: 소셜로그인 로직 보완

### DIFF
--- a/livestudy/src/main/java/org/livestudy/domain/user/User.java
+++ b/livestudy/src/main/java/org/livestudy/domain/user/User.java
@@ -87,11 +87,12 @@ public class User extends BaseEntity {
     public static User ofSocial(String email,
                                 String nickname,
                                 String profileImage,
-                                SocialProvider socialProvider) {
+                                SocialProvider socialProvider,
+                                String socialId) {
 
         //이메일이 없을 경우 임의의 이메일 생성
-        if (email == null) {
-            email = socialProvider.name() + "_" + UUID.randomUUID().toString() +"@livestudy.com";
+        if (email == null || email.isBlank()) {
+            email = socialProvider.name().toLowerCase() + "_" + socialId +"@livestudy.com";
         }
 
         return User.builder()

--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -64,7 +64,6 @@ spring.security.oauth2.client.provider.naver.user-name-attribute=response.id
 
 # Frontend URL (CORS ? ??????)
 app.frontend.url=https://live-study.com
-app.frontend.success-redirect-uri=https://live-study.com/auth/success
 
 # ?? ?? ??
 logging.level.root=INFO


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 OAuth2 소셜 로그인을 안정화(email 없을 시 등)합니다.
 1. CustomOAuth2UserService에서 유저 조회 및 생성 등을 처리합니다.
 2. OAuth2AuthenticationSuccessHandler는 jwt 토큰 생성 및 리다이렉트를 담당합니다.
 3. 이메일이 없을 시, provider+socialId를 기반으로 이메일을 생성합니다.
 
# 변경된 사항
 1. OAuth2AuthenticationSuccessHandler의 determineTargetUrl메서드에 있는 유저 조회 및 생성 로직을 CustomOAuth2UserService의 processOAuth2User 메서드로 옮김.
 2. User의 ofSocial 메서드에 socialId 파라미터 생성.
 3. pp.frontend.success-redirect-uri 제거.
