### PR TITLE
feat: 이미지 수정 인증 변경 및 메서드 추가

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/ImageUploadController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/ImageUploadController.java
@@ -7,15 +7,23 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.livestudy.dto.ErrorResponse;
 import org.livestudy.service.ImageService;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @RestController
 @RequestMapping("/api/images")
 public class ImageUploadController {
 
     private final ImageService imageService;
+    private final Path fileStorageLocation = Paths.get("src/main/resources/static/images").toAbsolutePath().normalize();
 
     public ImageUploadController(ImageService imageService) {
         this.imageService = imageService;
@@ -37,5 +45,39 @@ public class ImageUploadController {
 
             String imageUrl = imageService.uploadImage(imageFile);
             return ResponseEntity.ok(imageUrl);
+    }
+
+    @GetMapping("/images/{fileName:.+}")
+    @Operation(summary = "프로필이미지 저장", description = "유저(자신)의 프로필 이미지를 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이미지가 성공적으로 저장되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "저장할 대상을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
+    })
+    public ResponseEntity<Resource> serveFile(@PathVariable String fileName) throws MalformedURLException {
+        Path filePath = this.fileStorageLocation.resolve(fileName).normalize();
+        Resource resource = new UrlResource(filePath.toUri());
+
+        if (resource.exists()) {
+            String contentType = "application/octet-stream";
+
+            // 파일 이름 확장자에 따라 Content-Type 설정 (MIME 타입)
+            if (fileName.endsWith(".png")) {
+                contentType = "image/png";
+            } else if (fileName.endsWith(".jpg") || fileName.endsWith(".jpeg")) {
+                contentType = "image/jpeg";
+            }
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_TYPE, contentType)
+                    .body(resource);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/livestudy/src/main/java/org/livestudy/controller/ImageUploadController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/ImageUploadController.java
@@ -48,14 +48,14 @@ public class ImageUploadController {
     }
 
     @GetMapping("/images/{fileName:.+}")
-    @Operation(summary = "프로필이미지 저장", description = "유저(자신)의 프로필 이미지를 저장합니다.")
+    @Operation(summary = "프로필이미지 조회", description = "유저(자신)의 프로필 이미지를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "이미지가 성공적으로 저장되었습니다."),
+            @ApiResponse(responseCode = "200", description = "이미지가 성공적으로 조회되었습니다."),
             @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "저장할 대상을 찾을 수 없습니다.",
+            @ApiResponse(responseCode = "404", description = "조회할 대상을 찾을 수 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생.")
     })


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 이미지 수정 작업 로직을 리팩토링합니다.
 1. 이미지 수정 작업 중 GET(조회), POST(등록) 작업은 인증 없이 접근이 가능합니다(수정 작업만 인증이 필요하다고 판단하였습니다).
 2. serveFile 메서드를 생성하고 이미지 파일 타입에 따라 contentType을 지정합니다.
 
# 변경된 사항
 1. SecurityConfig에서 HttpMethod.POST, "/api/images/upload", HttpMethod.GET, "/images/**"에 permitAll 추가.
 2. ImageUploadController의 serveFile 메서드 생성
