### PR TITLE
feat: 네이버/구글 소셜로그인 로직 생성

### DIFF
--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.livestudy.config;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.livestudy.oauth2.CustomOAuth2UserService;
+import org.livestudy.oauth2.CustomOidcUserService;
 import org.livestudy.oauth2.OAuth2AuthenticationFailureHandler;
 import org.livestudy.oauth2.OAuth2AuthenticationSuccessHandler;
 import org.livestudy.security.jwt.JwtAuthenticationFilter;
@@ -44,6 +45,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity,
                                                    CustomOAuth2UserService customOAuth2UserService,
+                                                   CustomOidcUserService customOidcUserService,
                                                    OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
                                                    OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler
     ) throws Exception {
@@ -86,7 +88,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuth2UserService))
+                                .userService(customOAuth2UserService)
+                                .oidcUserService(customOidcUserService))
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureHandler(oAuth2AuthenticationFailureHandler))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/livestudy/src/main/java/org/livestudy/oauth2/CustomOAuth2UserService.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/CustomOAuth2UserService.java
@@ -29,14 +29,28 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         try {
             return processOAuth2User(userRequest, oauth2User);
-        } catch (Exception ex) {
-            throw new OAuth2AuthenticationException(ex.getMessage());
+        } catch (OAuth2AuthenticationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OAuth2AuthenticationException(
+                    new org.springframework.security.oauth2.core.OAuth2Error("server_error"),
+                    "OAuth2 login failed: " + e.getMessage()
+            );
         }
     }
 
     private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oauth2User.getAttributes());
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory
+                .getOAuth2UserInfo(registrationId, oauth2User.getAttributes());
+
+        // 필수값 체크
+        if (oAuth2UserInfo.getId() == null) {
+            throw new OAuth2AuthenticationException(
+                    new org.springframework.security.oauth2.core.OAuth2Error("invalid_user_info"),
+                    registrationId + " userinfo invalid: missing id"
+            );
+        }
 
         //email이 없을 경우 생성
         String email = oAuth2UserInfo.getEmail();

--- a/livestudy/src/main/java/org/livestudy/oauth2/CustomOidcUserService.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/CustomOidcUserService.java
@@ -1,0 +1,85 @@
+package org.livestudy.oauth2;
+
+import lombok.RequiredArgsConstructor;
+import org.livestudy.domain.user.SocialProvider;
+import org.livestudy.domain.user.User;
+import org.livestudy.exception.CustomException;
+import org.livestudy.exception.ErrorCode;
+import org.livestudy.repository.UserRepository;
+import org.livestudy.security.SecurityUser;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService extends OidcUserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OidcUser oidcUser = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // "google"
+        OAuth2UserInfo info = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oidcUser.getAttributes());
+
+        // email이 없을 경우 생성
+        String email = info.getEmail();
+        if (!StringUtils.hasText(email)) {
+            email = info.getProvider().name().toLowerCase()
+                    + "_" + info.getId()
+                    + "@livestudy.com";
+        }
+
+        User user = upsertUser(email, info);
+
+        return new SecurityUser(
+                user,
+                oidcUser.getAttributes(),
+                oidcUser.getIdToken(),
+                oidcUser.getUserInfo()
+        );
+    }
+
+    private User upsertUser(String email, OAuth2UserInfo info) {
+        Optional<User> found = userRepository.findByEmail(email);
+
+        if (found.isPresent()) {
+            User u = found.get();
+            if (!u.getSocialProvider().equals(info.getProvider())) {
+                throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+            }
+            u.setNewUser(false);
+            return u;
+        } else {
+            User nu = User.ofSocial(
+                    email,
+                    generateUniqueNickname(info.getName()),
+                    info.getImageUrl(),
+                    info.getProvider(),
+                    info.getId()
+            );
+            nu.setNewUser(true);
+            return userRepository.save(nu);
+        }
+    }
+
+    private String generateUniqueNickname(String base) {
+        if (!StringUtils.hasText(base)) base = "사용자";
+        String nick = base;
+        int i = 1;
+        while (userRepository.findByNickname(nick).isPresent()) {
+            nick = base + i++;
+        }
+        return nick;
+    }
+}

--- a/livestudy/src/main/java/org/livestudy/oauth2/NaverOAuth2UserInfo.java
+++ b/livestudy/src/main/java/org/livestudy/oauth2/NaverOAuth2UserInfo.java
@@ -1,18 +1,26 @@
 package org.livestudy.oauth2;
 
 import org.livestudy.domain.user.SocialProvider;
+import org.springframework.util.StringUtils;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class NaverOAuth2UserInfo extends OAuth2UserInfo {
 
+    private final Map<String, Object> response;
+
     public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+
         super(attributes);
+        Object resp = attributes.get("response");
+        this.response = (resp instanceof Map)
+                ? (Map<String, Object>) resp
+                : Collections.emptyMap();
     }
 
     @Override
     public String getId() {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
             return null;
         }
@@ -21,16 +29,17 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getName() {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
             return null;
         }
-        return (String) response.get("nickname");
+        String nickname = (String) response.get("nickname");
+        String name = (String) response.get("name");
+
+        return StringUtils.hasText(nickname) ? nickname : name;
     }
 
     @Override
     public String getEmail() {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
             return null;
         }
@@ -39,7 +48,6 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getImageUrl() {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
             return null;
         }

--- a/livestudy/src/main/java/org/livestudy/security/SecurityUser.java
+++ b/livestudy/src/main/java/org/livestudy/security/SecurityUser.java
@@ -6,6 +6,9 @@ import org.livestudy.domain.user.UserStatus;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
@@ -14,21 +17,43 @@ import java.util.Map;
 
 
 @Getter
-public class SecurityUser implements UserDetails, OAuth2User {
+public class SecurityUser implements UserDetails, OAuth2User, OidcUser {
 
     private final User user;
     private Map<String, Object> attributes;
 
+    // ===== OIDC 전용 필드 =====
+    private final OidcIdToken idToken;
+    private final OidcUserInfo userInfo;
+
     // 일반 로그인용 생성자
     public SecurityUser(User user) {
+
         this.user = user;
+        this.idToken = null;
+        this.userInfo = null;
     }
 
     // OAuth2 로그인용 생성자
-    public SecurityUser(User user, Map<String, Object> attributes) {
+    public SecurityUser(User user,
+                        Map<String, Object> attributes) {
         this.user = user;
         this.attributes = attributes;
+        this.idToken = null;
+        this.userInfo = null;
     }
+
+    // OIDC 로그인용 생성자 (구글)
+    public SecurityUser(User user,
+                        Map<String, Object> attributes,
+                        OidcIdToken idToken,
+                        OidcUserInfo userInfo) {
+        this.user = user;
+        this.attributes = attributes;
+        this.idToken = idToken;
+        this.userInfo = userInfo;
+    }
+
 
     // UserDetails 인터페이스 구현
     @Override
@@ -67,5 +92,21 @@ public class SecurityUser implements UserDetails, OAuth2User {
     @Override
     public String getName() {
         return user.getId().toString();
+    }
+
+    // ===== OidcUser =====
+    @Override
+    public Map<String, Object> getClaims() {
+        return attributes != null ? attributes : Map.of();
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return idToken;
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return userInfo;
     }
 }

--- a/livestudy/src/main/resources/application.properties
+++ b/livestudy/src/main/resources/application.properties
@@ -60,7 +60,7 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
 spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
-spring.security.oauth2.client.provider.naver.user-name-attribute=response.id
+spring.security.oauth2.client.provider.naver.user-name-attribute=id
 
 # Frontend URL (CORS ? ??????)
 app.frontend.url=https://live-study.com


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 네이버/구글 소셜 로그인의 로직을 생성합니다.
 1. 구글은 OIDC를 지원하여 CustomOidcUserService를 통해 로그인을 진행합니다.
 2. 네이버는 response을 분해하여 확인하고 로그인을 진행합니다.
 
# 변경된 사항
 1. OIDC 관련 코드 생성.
