### PR TITLE
Infra/jeongsoo caddy seperate ws&rtc

### DIFF
--- a/livestudy/livekit-server/livekit-config/caddy.yaml
+++ b/livestudy/livekit-server/livekit-config/caddy.yaml
@@ -11,8 +11,8 @@ apps:
   tls:
     certificates:
       automate:
-        - live-study.com
-        - api.live-study.com
+        - live-study.com # FE
+        - api.live-study.com # BE
 
   http:
     servers:
@@ -37,7 +37,7 @@ apps:
           # 1. LiveKit /rtc → 7880
           - match:
               - host:
-                  - api.live-study.com
+                  - live-study.com
                 path:
                   - /rtc*
             handle:
@@ -46,11 +46,6 @@ apps:
                   - dial: 127.0.0.1:7880
                 transport:
                   protocol: http
-                headers:
-                  request:
-                    set:
-                      Connection: ["{>Connection}"]
-                      Upgrade: ["{>Upgrade}"]
 
           # 2. STOMP /ws → 8080 (Spring)
           - match:
@@ -64,11 +59,6 @@ apps:
                   - dial: 127.0.0.1:8080
                 transport:
                   protocol: http
-                headers:
-                  request:
-                    set:
-                      Connection: ["{>Connection}"]
-                      Upgrade: ["{>Upgrade}"]
 
           # 3. 기타 API → 8080 (Spring)
           - match:

--- a/livestudy/livekit-server/livekit-config/caddy.yaml
+++ b/livestudy/livekit-server/livekit-config/caddy.yaml
@@ -16,7 +16,7 @@ apps:
 
   http:
     servers:
-      redirect:  # ← HTTP 80 리디렉션 서버
+      redirect:
         listen:
           - ":80"
         routes:
@@ -30,13 +30,16 @@ apps:
                 headers:
                   Location: ["https://{http.request.host}{uri}"]
 
-      main:  # ← HTTPS 443 서버
+      main:
         listen:
           - ":443"
         routes:
+          # 1. LiveKit /rtc → 7880
           - match:
               - host:
-                  - live-study.com
+                  - api.live-study.com
+                path:
+                  - /rtc*
             handle:
               - handler: reverse_proxy
                 upstreams:
@@ -48,9 +51,13 @@ apps:
                     set:
                       Connection: ["{>Connection}"]
                       Upgrade: ["{>Upgrade}"]
+
+          # 2. STOMP /ws → 8080 (Spring)
           - match:
               - host:
                   - api.live-study.com
+                path:
+                  - /ws*
             handle:
               - handler: reverse_proxy
                 upstreams:
@@ -63,3 +70,11 @@ apps:
                       Connection: ["{>Connection}"]
                       Upgrade: ["{>Upgrade}"]
 
+          # 3. 기타 API → 8080 (Spring)
+          - match:
+              - host:
+                  - api.live-study.com
+            handle:
+              - handler: reverse_proxy
+                upstreams:
+                  - dial: 127.0.0.1:8080

--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                         .maxSessionsPreventsLogin(false))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/images/upload").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/images/**",  "/ws").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/images/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 // OAuth2
@@ -70,6 +70,11 @@ public class SecurityConfig {
                                 "/auth/**",
                                 // WebSocket 및 LiveKit
                                 "/chat-test.html",
+                                "/loca-test.html",
+                                "/ws",
+                                "/ws/**",
+                                "/rtc",
+                                "/rtc/**",
                                 // swagger
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                         .maxSessionsPreventsLogin(false))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/images/upload").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/images/**", "/api/study-rooms/ws/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/images/**",  "/ws").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 // OAuth2
@@ -69,7 +69,6 @@ public class SecurityConfig {
                                 "/login/oauth2/code/**",
                                 "/auth/**",
                                 // WebSocket 및 LiveKit
-                                "/ws",
                                 "/chat-test.html",
                                 // swagger
                                 "/swagger-ui/**",
@@ -89,7 +88,7 @@ public class SecurityConfig {
                                 "/api/timer/**",
                                 "/api/titles/**"
                         ).permitAll()
-                        .requestMatchers("/api/user/**", "/api/livekit/**", "/api/user/stat/**", "/api/study-rooms/**", "/api/study-rooms/ws/**", "/ws/**").authenticated()
+                        .requestMatchers("/api/user/**", "/api/livekit/**", "/api/user/stat/**", "/api/study-rooms/**", "/api/study-rooms/ws/**", "/ws/**", "/api/study-rooms/rtc/**").authenticated()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo

--- a/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
+++ b/livestudy/src/main/java/org/livestudy/config/SecurityConfig.java
@@ -93,7 +93,7 @@ public class SecurityConfig {
                                 "/api/timer/**",
                                 "/api/titles/**"
                         ).permitAll()
-                        .requestMatchers("/api/user/**", "/api/livekit/**", "/api/user/stat/**", "/api/study-rooms/**", "/api/study-rooms/ws/**", "/ws/**", "/api/study-rooms/rtc/**").authenticated()
+                        .requestMatchers("/api/user/**", "/api/livekit/**", "/api/user/stat/**", "/api/study-rooms/**", "/api/study-rooms/ws/**", "/api/study-rooms/rtc/**").authenticated()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
@@ -94,7 +94,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         // 스킵할 경로 명확히 지정
-        if (path.startsWith("/oauth2/") || path.startsWith("/api/auth/") || path.startsWith("/api/study-rooms/ws")) {
+        if (path.startsWith("/oauth2/")
+                || path.startsWith("/api/auth/")
+                || path.startsWith("/ws")) {
             log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);
             return true;
         }

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
@@ -87,16 +87,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
+        String servletPath = request.getServletPath();
+        String contextPath = request.getContextPath();
 
-        boolean skip = path.startsWith("/oauth2/") || path.startsWith("/api/auth/");
-        if (skip) {
-            log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);
-        }
+        log.debug("[JwtAuthenticationFilter] getRequestURI: {}", path);
+        log.debug("[JwtAuthenticationFilter] getServletPath: {}", servletPath);
+        log.debug("[JwtAuthenticationFilter] getContextPath: {}", contextPath);
 
         // 스킵할 경로 명확히 지정
         if (path.startsWith("/oauth2/")
                 || path.startsWith("/api/auth/")
-                || path.startsWith("/ws")) {
+                || path.startsWith("/ws")
+                || path.contains("/api/study-rooms/rtc")
+                || path.contains("/api/study-rooms/ws")
+                || path.startsWith("/loca-test.html")
+                || path.startsWith("/favicon.ico")) {
             log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);
             return true;
         }

--- a/livestudy/src/main/resources/static/loca-test.html
+++ b/livestudy/src/main/resources/static/loca-test.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <title>Local WebSocket & LiveKit RTC Test</title>
-  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script> <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 </head>
 <body>
 <h1>Local WebSocket & LiveKit RTC Test</h1>
@@ -49,110 +50,152 @@
     const password = document.getElementById("signup-password").value;
     const nickname = document.getElementById("signup-nickname").value;
     const introduction = document.getElementById("signup-intro").value;
+
     try {
-      const res = await fetch("/api/auth/signup",
-              { method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  email,
-                  password,
-                  nickname,
-                  introduction,
-                  profileImage: null,
-                  socialProvider: null }),
-              });
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          password,
+          nickname,
+          introduction,
+          profileImage: null,
+          socialProvider: null
+        }),
+      });
+
       if (res.status === 201) {
         alert("✅ 회원가입 성공! 로그인하세요.");
       } else {
-        const error = await res.text(); alert("❌ 회원가입 실패: " + error);
+        const error = await res.text();
+        alert("❌ 회원가입 실패: " + error);
       }
     } catch (err) {
       alert("❌ 회원가입 에러: " + err.message);
     }
-  } // 로그인 함수 수정
+  }
 
+  // 로그인 함수 수정
   async function loginUser() {
     const email = document.getElementById("login-email").value;
     const password = document.getElementById("login-password").value;
 
     try {
-      const res = await fetch("/api/auth/login",
-              { method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  email,
-                  password
-                }),
-              });
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
       const data = await res.json();
       jwtToken = data.token; // 전역 변수에 JWT 토큰 저장
       console.log("JWT Token:" , jwtToken);
-      alert("✅ 로그인 성공! LiveKit 토큰 발급 시도합니다."); // JWT 토큰으로 LiveKit 토큰 요청
-      const livekitRes = await fetch("/api/livekit/token",
-              { method: "POST",
-                headers: { "Authorization": "Bearer " + jwtToken,
-                  "Content-Type": "application/json" },
-                body: JSON.stringify({ roomName: "study-room-1", // roomId에 매핑됨
-                                       identity: "user_8890" // userId에 매핑됨
-               }) });
+      alert("✅ 로그인 성공! LiveKit 토큰 발급 시도합니다.");
+
+      // JWT 토큰으로 LiveKit 토큰 요청
+      const livekitRes = await fetch("/api/livekit/token", {
+        method: "POST",
+        headers: {
+          "Authorization": "Bearer " + jwtToken,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          roomName: "study-room-1", // roomId에 매핑됨
+          identity: "user_8890"     // userId에 매핑됨
+        })
+      });
       const livekitData = await livekitRes.json();
       const livekitToken = livekitData.token;
-      console.log("livekitToken:", livekitToken); // LiveKit 토큰은 RTC 연결에 사용
-      await connectRtc(livekitToken); // JWT 토큰은 STOMP 웹소켓 연결에 사용
-      connectWs(jwtToken); // 인자 없이 호출
-    } catch (err) { alert("❌ 로그인 실패: " + err.message); } }
+      console.log("livekitToken:", livekitToken);
 
+      // LiveKit 토큰은 RTC 연결에 사용
+      await connectRtc(livekitToken);
+
+      // JWT 토큰은 STOMP 웹소켓 연결에 사용
+      connectWs(jwtToken); // 인자 없이 호출
+
+    } catch (err) {
+      alert("❌ 로그인 실패: " + err.message);
+    }
+  }
 
   function connectWs() {
     if (stompClient && stompClient.connected) {
       log('ws-log', 'Already connected');
       return;
-    } // 전역 변수 jwtToken을 사용
+    }
 
+    // 전역 변수 jwtToken을 사용
     if (!jwtToken) {
       log('ws-log', '❌ JWT 토큰이 없습니다. 먼저 로그인하세요.');
-      return; }
+      return;
+    }
 
-    const socket = new SockJS('http://localhost/ws');
-
+    const socket = new SockJS('https://live-study.com/ws');
     stompClient = Stomp.over(socket);
 
-    const headers = { 'Authorization': Bearer, ${jwtToken} };
+    const headers = {
+      'Authorization': `Bearer ${jwtToken}`
+    };
 
     stompClient.connect(headers, frame => {
       log('ws-log', 'Connected: ' + frame);
-      stompClient.subscribe('/topic/test', message =>
-      { log('ws-log', 'Received: ' + message.body); }); },
-            error => { log('ws-log', 'Error: ' + error); }); }
+      stompClient.subscribe('/topic/test', message => {
+        log('ws-log', 'Received: ' + message.body);
+      });
+    }, error => {
+      log('ws-log', 'Error: ' + error);
+    });
+  }
 
   function sendWs() {
     if (stompClient && stompClient.connected) {
       stompClient.send('/app/test', {}, 'Hello from local /ws');
       log('ws-log', 'Sent message: Hello from local /ws');
-    } else { log('ws-log', 'Not connected'); }
-  } // LiveKit WebSocket 연결
+    } else {
+      log('ws-log', 'Not connected');
+    }
+  }
 
+
+
+
+
+
+  // LiveKit WebSocket 연결
   async function connectRtc(livekitToken) { // 토큰을 인자로 받도록 수정
     if (rtcSocket && rtcSocket.readyState === WebSocket.OPEN) {
       log('rtc-log', 'Already connected');
-      return; } // 인자로 받은 livekitToken을 사용
+      return;
+    }
 
+    // 인자로 받은 livekitToken을 사용
     if (!livekitToken) {
       log('rtc-log', 'No token provided, cannot connect');
-      return; } // LiveKit 서버 URL에 access_token을 포함하여 연결
+      return;
+    }
 
-    const wsUrl = 'ws://localhost/rtc?access_token=${livekitToken}';
-    log('rtc-log', 'Connecting to WebSocket:' + ${wsUrl});
+    // LiveKit 서버 URL에 access_token을 포함하여 연결
+    const wsUrl = `wss://api.live-study.com/rtc?access_token=${livekitToken}`;
+
+    log('rtc-log', `Connecting to WebSocket: ${wsUrl}`);
+
     rtcSocket = new WebSocket(wsUrl);
+
     rtcSocket.onopen = () => log('rtc-log', 'Connected to /rtc');
     rtcSocket.onmessage = e => log('rtc-log', 'Message: ' + e.data);
     rtcSocket.onerror = e => log('rtc-log', 'Error: ' + JSON.stringify(e));
-    rtcSocket.onclose = () => log('rtc-log', 'Disconnected from /rtc'); } // 로그 출력
+    rtcSocket.onclose = () => log('rtc-log', 'Disconnected from /rtc');
+  }
 
+  // 로그 출력
   function log(id, message) {
     const el = document.getElementById(id);
     el.innerHTML += message + '\n';
-    el.scrollTop = el.scrollHeight; }
+    el.scrollTop = el.scrollHeight;
+  }
+
+
 </script>
 </body>
 </html>

--- a/livestudy/src/main/resources/static/loca-test.html
+++ b/livestudy/src/main/resources/static/loca-test.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Local WebSocket & LiveKit RTC Test</title>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script> <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+</head>
+<body>
+<h1>Local WebSocket & LiveKit RTC Test</h1>
+
+<section>
+  <h2>회원가입</h2>
+  <label for="signup-email"></label><input id="signup-email" placeholder="email" />
+  <label for="signup-password"></label><input id="signup-password" placeholder="password" type="password" />
+  <label for="signup-nickname"></label><input id="signup-nickname" placeholder="닉네임" />
+  <label for="signup-intro"></label><input id="signup-intro" placeholder="자기소개" />
+  <button onclick="signup()">Sign Up</button>
+</section>
+
+<section>
+  <h2>로그인</h2>
+  <label for="login-email"></label><input id="login-email" placeholder="email" />
+  <label for="login-password"></label><input id="login-password" placeholder="password" type="password" />
+  <button onclick="loginUser()">Login</button>
+</section>
+
+<section>
+  <h2>/ws (Spring STOMP)</h2>
+  <button onclick="connectWs()">Connect to /ws</button>
+  <button onclick="sendWs()">Send Message to /topic/test</button>
+  <div id="ws-log" style="white-space: pre-wrap; border: 1px solid #ccc; padding: 8px; height: 120px; overflow-y: auto;"></div>
+</section>
+
+<hr />
+
+<section>
+  <h2>/rtc (LiveKit WebSocket)</h2>
+  <button onclick="connectRtc()">Connect to /rtc</button>
+  <div id="rtc-log" style="white-space: pre-wrap; border: 1px solid #ccc; padding: 8px; height: 120px; overflow-y: auto;"></div>
+</section>
+
+<script>
+  let jwtToken = null; // 로그인 후 받은 JWT 토큰을 저장할 전역 변수
+  let stompClient = null;
+  let rtcSocket = null;
+
+  async function signup() {
+    const email = document.getElementById("signup-email").value;
+    const password = document.getElementById("signup-password").value;
+    const nickname = document.getElementById("signup-nickname").value;
+    const introduction = document.getElementById("signup-intro").value;
+    try {
+      const res = await fetch("/api/auth/signup",
+              { method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  email,
+                  password,
+                  nickname,
+                  introduction,
+                  profileImage: null,
+                  socialProvider: null }),
+              });
+      if (res.status === 201) {
+        alert("✅ 회원가입 성공! 로그인하세요.");
+      } else {
+        const error = await res.text(); alert("❌ 회원가입 실패: " + error);
+      }
+    } catch (err) {
+      alert("❌ 회원가입 에러: " + err.message);
+    }
+  } // 로그인 함수 수정
+
+  async function loginUser() {
+    const email = document.getElementById("login-email").value;
+    const password = document.getElementById("login-password").value;
+
+    try {
+      const res = await fetch("/api/auth/login",
+              { method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  email,
+                  password
+                }),
+              });
+      const data = await res.json();
+      jwtToken = data.token; // 전역 변수에 JWT 토큰 저장
+      console.log("JWT Token:" , jwtToken);
+      alert("✅ 로그인 성공! LiveKit 토큰 발급 시도합니다."); // JWT 토큰으로 LiveKit 토큰 요청
+      const livekitRes = await fetch("/api/livekit/token",
+              { method: "POST",
+                headers: { "Authorization": "Bearer " + jwtToken,
+                  "Content-Type": "application/json" },
+                body: JSON.stringify({ roomName: "study-room-1", // roomId에 매핑됨
+                                       identity: "user_8890" // userId에 매핑됨
+               }) });
+      const livekitData = await livekitRes.json();
+      const livekitToken = livekitData.token;
+      console.log("livekitToken:", livekitToken); // LiveKit 토큰은 RTC 연결에 사용
+      await connectRtc(livekitToken); // JWT 토큰은 STOMP 웹소켓 연결에 사용
+      connectWs(jwtToken); // 인자 없이 호출
+    } catch (err) { alert("❌ 로그인 실패: " + err.message); } }
+
+
+  function connectWs() {
+    if (stompClient && stompClient.connected) {
+      log('ws-log', 'Already connected');
+      return;
+    } // 전역 변수 jwtToken을 사용
+
+    if (!jwtToken) {
+      log('ws-log', '❌ JWT 토큰이 없습니다. 먼저 로그인하세요.');
+      return; }
+
+    const socket = new SockJS('http://localhost/ws');
+
+    stompClient = Stomp.over(socket);
+
+    const headers = { 'Authorization': Bearer, ${jwtToken} };
+
+    stompClient.connect(headers, frame => {
+      log('ws-log', 'Connected: ' + frame);
+      stompClient.subscribe('/topic/test', message =>
+      { log('ws-log', 'Received: ' + message.body); }); },
+            error => { log('ws-log', 'Error: ' + error); }); }
+
+  function sendWs() {
+    if (stompClient && stompClient.connected) {
+      stompClient.send('/app/test', {}, 'Hello from local /ws');
+      log('ws-log', 'Sent message: Hello from local /ws');
+    } else { log('ws-log', 'Not connected'); }
+  } // LiveKit WebSocket 연결
+
+  async function connectRtc(livekitToken) { // 토큰을 인자로 받도록 수정
+    if (rtcSocket && rtcSocket.readyState === WebSocket.OPEN) {
+      log('rtc-log', 'Already connected');
+      return; } // 인자로 받은 livekitToken을 사용
+
+    if (!livekitToken) {
+      log('rtc-log', 'No token provided, cannot connect');
+      return; } // LiveKit 서버 URL에 access_token을 포함하여 연결
+
+    const wsUrl = 'ws://localhost/rtc?access_token=${livekitToken}';
+    log('rtc-log', 'Connecting to WebSocket:' + ${wsUrl});
+    rtcSocket = new WebSocket(wsUrl);
+    rtcSocket.onopen = () => log('rtc-log', 'Connected to /rtc');
+    rtcSocket.onmessage = e => log('rtc-log', 'Message: ' + e.data);
+    rtcSocket.onerror = e => log('rtc-log', 'Error: ' + JSON.stringify(e));
+    rtcSocket.onclose = () => log('rtc-log', 'Disconnected from /rtc'); } // 로그 출력
+
+  function log(id, message) {
+    const el = document.getElementById(id);
+    el.innerHTML += message + '\n';
+    el.scrollTop = el.scrollHeight; }
+</script>
+</body>
+</html>


### PR DESCRIPTION
/rtc 연결 & /ws 연결 확립

- 로컬에서 검증 진행 후 외부 서버 설정에 맞게 올립니다.
변경사항은 다음과 같습니다.

- caddy.yaml : Upgrade & Connection Header 제거 -> 확실히 명시해줄 수 있는 path_prefix, uri 모듈이 저희가 사용하고 있는 caddy version에서는 없는 것으로 파악이 되었습니다.
- loca-test.html 추가 : rtc & ws 연결 테스트를 위한 static 파일입니다.
- SecurityConfig.java : /ws, /ws/**, /rtc, /rtc/** 를 모두 허용하는 설정을 추가하였습니다.
- JwtAuthenticationFilter.java : /ws, /api/study-rooms/rtc 를 포함하는 경로에 Filtering 적용하는 것을 배제하도록 ShouldnotFilter Method에 경로를 추가하였습니다.