### PR TITLE
ws & rtc 변경 내역 3번째

### DIFF
--- a/livestudy/livekit-server/livekit-config/caddy.yaml
+++ b/livestudy/livekit-server/livekit-config/caddy.yaml
@@ -44,8 +44,6 @@ apps:
               - handler: reverse_proxy
                 upstreams:
                   - dial: 127.0.0.1:7880
-                transport:
-                  protocol: http
 
           # 2. STOMP /ws → 8080 (Spring)
           - match:
@@ -57,8 +55,6 @@ apps:
               - handler: reverse_proxy
                 upstreams:
                   - dial: 127.0.0.1:8080
-                transport:
-                  protocol: http
 
           # 3. 기타 API → 8080 (Spring)
           - match:

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String path =  request.getRequestURI();
 
-        if(path.contains("/api/study-rooms/ws/**")) {
+        if(path.contains("/ws/**")) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -99,7 +99,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/auth/")
                 || path.startsWith("/ws")
                 || path.contains("/api/study-rooms/rtc")
-                || path.contains("/api/study-rooms/ws")
                 || path.startsWith("/loca-test.html")
                 || path.startsWith("/favicon.ico")) {
             log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);

--- a/livestudy/src/main/java/org/livestudy/websocket/security/JwtHandshakeInterceptor.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/security/JwtHandshakeInterceptor.java
@@ -39,7 +39,10 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
                 .build().getQueryParams()
                 .getFirst("access_token");
 
-
+        if(requestPath.startsWith("/ws")){
+            log.info("/ws 연결 : 토큰 없음 허용");
+            return true;
+        }
 
 
 


### PR DESCRIPTION
- caddy.yaml의 http Protocol 명시 제거
- JwtAuthenticationFilter에서 path.contains("/ws/**")은 진행 안 해도 되게끔 변경

- JwtHandshakeInterceptor.java에서 /ws 연결 시 토큰 없음 허용 로그와 로직 부여