### PR TITLE
Infra/jeongsoo caddy seperate ws&rtc final

### DIFF
--- a/livestudy/livekit-server/livekit-config/caddy.yaml
+++ b/livestudy/livekit-server/livekit-config/caddy.yaml
@@ -38,6 +38,7 @@ apps:
           - match:
               - host:
                   - live-study.com
+                  - api.live-study.com
                 path:
                   - /rtc*
             handle:
@@ -47,6 +48,9 @@ apps:
                 headers:
                   response:
                     set:
+                      X-Forwarded-For: [ "{remote_host}" ]
+                      X-Forwarded-Proto: [ "{scheme}" ]
+                      Host: [ "{host}" ]
                       Access-Control-Allow-Origin: [ "{http.request.header.Origin}" ]
                       Access-Control-Allow-Credentials: [ "true" ]
                       Access-Control-Allow-Methods: [ "GET, POST, PUT, DELETE, PATCH, OPTIONS" ]

--- a/livestudy/livekit-server/livekit-config/caddy.yaml
+++ b/livestudy/livekit-server/livekit-config/caddy.yaml
@@ -44,6 +44,13 @@ apps:
               - handler: reverse_proxy
                 upstreams:
                   - dial: 127.0.0.1:7880
+                headers:
+                  response:
+                    set:
+                      Access-Control-Allow-Origin: [ "{http.request.header.Origin}" ]
+                      Access-Control-Allow-Credentials: [ "true" ]
+                      Access-Control-Allow-Methods: [ "GET, POST, PUT, DELETE, PATCH, OPTIONS" ]
+                      Access-Control-Allow-Headers: [ "Content-Type, Authorization" ]
 
           # 2. STOMP /ws → 8080 (Spring)
           - match:
@@ -55,6 +62,14 @@ apps:
               - handler: reverse_proxy
                 upstreams:
                   - dial: 127.0.0.1:8080
+                headers:
+                  response:
+                    set:
+                      Access-Control-Allow-Origin: [ "{http.request.header.Origin}" ]
+                      Access-Control-Allow-Credentials: [ "true" ]
+                      Access-Control-Allow-Methods: [ "GET, POST, PUT, DELETE, PATCH, OPTIONS" ]
+                      Access-Control-Allow-Headers: [ "Content-Type, Authorization" ]
+
 
           # 3. 기타 API → 8080 (Spring)
           - match:

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
@@ -98,7 +98,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (path.startsWith("/oauth2/")
                 || path.startsWith("/api/auth/")
                 || path.startsWith("/ws")
-                || path.contains("/api/study-rooms/rtc")
+                || path.contains("/rtc")
                 || path.startsWith("/loca-test.html")
                 || path.startsWith("/favicon.ico")) {
             log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);

--- a/livestudy/src/main/java/org/livestudy/websocket/StompAuthChannelInterceptor.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/StompAuthChannelInterceptor.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.livestudy.exception.CustomException;
 import org.livestudy.exception.ErrorCode;
+import org.livestudy.security.jwt.JwtTokenProvider;
 import org.livestudy.service.livekit.LiveKitTokenService;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     private final LiveKitTokenService liveKitTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public Message<?> preSend(@NotNull Message<?> message, @NotNull MessageChannel channel) {
@@ -58,23 +60,41 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             log.info("[CONNECT] JWT token extracted: {}", token);
 
             try {
-                boolean valid = liveKitTokenService.validateToken(token);
-                log.info("[CONNECT] Token validation result: {}", valid);
+                boolean valid = false;
+                Authentication auth = null;
 
-                if (!valid) {
-                    log.warn("[CONNECT] Invalid JWT token.");
+                try{
+                    valid = liveKitTokenService.validateToken(token);
+                    if(valid) {
+                        auth = liveKitTokenService.getAuthentication(token);
+                        log.info("Successfully authenticated with LiveKit Token");
+                    }
+                } catch (Exception e) {
+                    log.debug("LiveKit token validation failed, attempting to validate as general JWT");
+                }
+
+                if(auth == null) {
+                    valid = jwtTokenProvider.validateToken(token);
+                    if(valid) {
+                        auth = jwtTokenProvider.getAuthentication(token);
+                        log.info("Successfully authenticated with general JWT token.");
+                    }
+                }
+
+                if(!valid){
+                    log.warn("[preSend] Invalid token. Neither a valid LiveKit nor a general JWT Token");
                     throw new CustomException(ErrorCode.FORBIDDEN);
                 }
 
-                Authentication auth = liveKitTokenService.getAuthentication(token);
-                log.info("[CONNECT] Authenticated user: {}", auth.getName());
-
+                log.info("[preSend] Authenticated user : {}", auth.getName());
                 accessor.setUser(auth);
-                log.debug("[CONNECT] Principal set in accessor: {}", accessor.getUser());
+
+
             } catch (Exception e) {
                 log.error("[CONNECT] Token processing failed: {}", e.getMessage(), e);
                 throw new CustomException(ErrorCode.FORBIDDEN);
             }
+
         } else {
             log.debug("[{}] Skipping authentication, current user in accessor: {}", command, accessor.getUser());
         }

--- a/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/WebSocketConfiguration.java
@@ -31,7 +31,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("http://localhost:5174", "https://localhost:5174", // FE 개발용
                         "https://live-study.com", "https://www.live-study.com", "https://api.live-study.com")  // 배포용
-                .addInterceptors(jwtHandshakeInterceptor) // 주소 도달 시 입장용 토큰에 대하여 인증을 진행한다!
+                .addInterceptors(jwtHandshakeInterceptor)// 주소 도달 시 입장용 토큰에 대하여 인증을 진행한다!
                 .withSockJS();
     }
 

--- a/livestudy/src/main/java/org/livestudy/websocket/security/JwtHandshakeInterceptor.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/security/JwtHandshakeInterceptor.java
@@ -47,6 +47,8 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
             return true;
         }
 
+        httpResponse.getHeaders().set("Access-Control-Allow-Origin", "https://live-study.com");
+        httpResponse.getHeaders().set("Access-Control-Allow-Credentials", "true");
 
 
         log.info("🛡️ WS Handshake 요청: path={}, ip={}, token={}", requestPath, ip, token != null ? "present" : "missing");

--- a/livestudy/src/main/java/org/livestudy/websocket/security/JwtHandshakeInterceptor.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/security/JwtHandshakeInterceptor.java
@@ -35,6 +35,9 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
         String requestPath = httpRequest.getURI().getPath();
         String ip = httpRequest.getRemoteAddress() != null ? httpRequest.getRemoteAddress().toString() : "unknown";
 
+        httpResponse.getHeaders().set("Access-Control-Allow-Origin", "https://live-study.com");
+        httpResponse.getHeaders().set("Access-Control-Allow-Credentials", "true");
+
         String token = UriComponentsBuilder.fromUri(httpRequest.getURI())
                 .build().getQueryParams()
                 .getFirst("access_token");


### PR DESCRIPTION
최종 ws & rtc 연결 점검 결과

-. 현재 서버 설정에서 rtc 연결은 정상적으로 가동하고 있습니다. 만료 기간은 24시간으로 설정해두었으니, 참고 부탁 드립니다.
-. ws 연결은 현재 프록시 대상 서버에 Vercel로 설정되어 있기에, 제가 Access-Origin-Allow-Header가 *로 표시되는 부분에 대해 건드릴 수 없는 상황입니다. 현재 200OK 로 발생 중입니다.
(FE 분들에게 요청드릴 예정입니다.)

- 로컬에서 검증은 모두 ws & rtc 연결 모두 검증을 마쳤으며, 외부 서버에서는 현재 rtc 연결까지 모두 검증이 완료된 상황입니다.

- caddy.yaml에서 7880에 도메인 대상 추가 : https://api.live-study.com
- 또한, caddy.yaml에서 ws 연결에 대해 Access-Origin-Allow-Origins, Credentials, Methods, Headers에 대한 설정을 추가했습니다.
- 먼저, 공유드려야 될 점은 Headers에 대한 설정이 Content-Type, Authorization 두 가지입니다. 만약 이 Headers에 대한 설정을 추가해야 될 경우 먼저 말씀 부탁 드립니다. 반영하도록 하겠습니다.
- StompAuthChannelInterceptor.java에서 JWT 토큰도 후순위로 검증하는 로직을 추가했습니다.