### PR TITLE
feat: refresh 토큰 생성

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/AuthController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/AuthController.java
@@ -6,14 +6,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.livestudy.dto.UserLoginRequest;
 import org.livestudy.dto.UserLoginResponse;
 import org.livestudy.dto.UserSignupRequest;
+import org.livestudy.security.SecurityUser;
+import org.livestudy.security.jwt.JwtTokenProvider;
+import org.livestudy.service.RefreshTokenService;
 import org.livestudy.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -25,11 +31,17 @@ import java.util.Map;
 public class  AuthController {
 
     private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     private static final Logger log = LoggerFactory.getLogger(AuthController.class);
 
-    public AuthController(UserService userService) {
+    public AuthController(UserService userService,
+                          RefreshTokenService refreshTokenService,
+                          JwtTokenProvider jwtTokenProvider) {
         this.userService = userService;
+        this.refreshTokenService = refreshTokenService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     // 이메일 회원가입
@@ -69,9 +81,58 @@ public class  AuthController {
                     required = true,
                     content = @Content(schema = @Schema(implementation = UserLoginRequest.class))
             )
-            @RequestBody UserLoginRequest request){
+            @RequestBody UserLoginRequest request, HttpServletResponse res){
         UserLoginResponse response = userService.login(request);
+
+        String refresh = refreshTokenService.issue(response.getUserId());
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", refresh)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("Strict")
+                .maxAge(java.time.Duration.ofDays(14))
+                .build();
+        res.addHeader("Set-Cookie", cookie.toString());
+
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "액세스 토큰 재발급", description = "쿠키의 리프레시 토큰으로 새 액세스 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "리프레시 만료/무효",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    public ResponseEntity<Map<String, String>> refresh(
+            @CookieValue(value = "refresh_token", required = false) String raw,
+            HttpServletResponse res) {
+
+        Long userId = refreshTokenService.verifyAndConsume(raw);
+        if (userId == null) {
+            ResponseCookie clear = ResponseCookie.from("refresh_token", "")
+                    .httpOnly(true).secure(true).path("/").sameSite("Strict")
+                    .maxAge(java.time.Duration.ZERO).build();
+            res.addHeader("Set-Cookie", clear.toString());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("code", "REFRESH_EXPIRED"));
+        }
+
+        var user = userService.getUserById(String.valueOf(userId));
+        SecurityUser principal = new SecurityUser(user);
+        var auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                principal.getAuthorities());
+        String newAccess = jwtTokenProvider.generateToken(auth);
+        String newRefresh = refreshTokenService.issue(userId);
+
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", newRefresh)
+                .httpOnly(true).secure(true).path("/").sameSite("Strict")
+                .maxAge(java.time.Duration.ofDays(14)).build();
+        res.addHeader("Set-Cookie", cookie.toString());
+
+        return ResponseEntity.ok(Map.of("accessToken", newAccess));
     }
 
 /*    // OAuth2 로그인 URL 제공

--- a/livestudy/src/main/java/org/livestudy/dto/UserLoginResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/UserLoginResponse.java
@@ -10,4 +10,7 @@ import lombok.Data;
 public class UserLoginResponse {
     @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1...")
     private String token;
+
+    @Schema(description = "userId", example = "12453")
+    private Long userId;
 }

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package org.livestudy.security.jwt;
 
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,30 +36,37 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String path =  request.getRequestURI();
 
-        if(path.contains("/api/study-rooms/ws/**")) {
+        if(path.contains("/ws/**")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-
         log.debug("[JwtAuthenticationFilter] 추출된 토큰: {}", token != null ? token : "없음");
 
-
-        if(token != null && jwtTokenProvider.validateToken(token)) {
-            if (jwtTokenProvider.validateToken(token)) {
-                log.debug("[JwtAuthenticationFilter] 토큰 유효성 검증 성공");
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                log.debug("[JwtAuthenticationFilter] Authentication 객체 생성: {}", authentication);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("[JwtAuthenticationFilter] SecurityContext에 Authentication 저장 완료");
+        try {
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                if (jwtTokenProvider.validateToken(token)) {
+                    log.debug("[JwtAuthenticationFilter] 토큰 유효성 검증 성공");
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                    log.debug("[JwtAuthenticationFilter] Authentication 객체 생성: {}", authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.debug("[JwtAuthenticationFilter] SecurityContext에 Authentication 저장 완료");
+                } else {
+                    log.warn("[JwtAuthenticationFilter] 토큰 유효성 검증 실패");
+                }
             } else {
-                log.warn("[JwtAuthenticationFilter] 토큰 유효성 검증 실패");
+                log.debug("[JwtAuthenticationFilter] 토큰이 없으므로 인증 처리 건너뜀");
             }
-        } else {
-            log.debug("[JwtAuthenticationFilter] 토큰이 없으므로 인증 처리 건너뜀");
-        }
-
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException ex) {
+            log.warn("[JwtAuthenticationFilter] 액세스 토큰 만료: {}", ex.getMessage());
+            writeJson(response, 401, "{\"code\":\"TOKEN_EXPIRED\",\"message\":\"access token expired\"}");
+            return;
+        } catch (JwtException | IllegalArgumentException ex) {
+            log.warn("[JwtAuthenticationFilter] JWT 오류: {}", ex.getMessage());
+            writeJson(response, 401, "{\"code\":\"INVALID_TOKEN\",\"message\":\"invalid token\"}");
+            return;
+            }
     }
 
     // Authorization에서 JWT 값을 추출
@@ -87,14 +96,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
+        String servletPath = request.getServletPath();
+        String contextPath = request.getContextPath();
 
-        boolean skip = path.startsWith("/oauth2/") || path.startsWith("/api/auth/");
-        if (skip) {
-            log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);
-        }
+        log.debug("[JwtAuthenticationFilter] getRequestURI: {}", path);
+        log.debug("[JwtAuthenticationFilter] getServletPath: {}", servletPath);
+        log.debug("[JwtAuthenticationFilter] getContextPath: {}", contextPath);
 
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) return true;
         // 스킵할 경로 명확히 지정
-        if (path.startsWith("/oauth2/") || path.startsWith("/api/auth/") || path.startsWith("/api/study-rooms/ws")) {
+        if (path.startsWith("/oauth2/")
+                || path.startsWith("/api/auth/")
+                || path.startsWith("/ws")
+                || path.contains("/rtc")
+                || path.startsWith("/loca-test.html")
+                || path.startsWith("/favicon.ico")) {
             log.debug("[JwtAuthenticationFilter] shouldNotFilter 적용: {} → 필터 스킵", path);
             return true;
         }
@@ -102,5 +118,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return false; // 그 외 요청은 필터 실행
     }
 
-    
+    private static void writeJson(HttpServletResponse res, int status, String body) throws java.io.IOException {
+        if (res.isCommitted()) return;
+        res.setStatus(status);
+        res.setContentType("application/json");
+        res.setCharacterEncoding("UTF-8");
+        res.getWriter().write(body);
+        }
+
 }

--- a/livestudy/src/main/java/org/livestudy/security/jwt/JwtTokenProvider.java
+++ b/livestudy/src/main/java/org/livestudy/security/jwt/JwtTokenProvider.java
@@ -81,7 +81,9 @@ public class JwtTokenProvider {
         try {
             jwtParser.parseClaimsJws(token);
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            throw e;
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
             e.printStackTrace();
             return false;
         }

--- a/livestudy/src/main/java/org/livestudy/service/RefreshTokenService.java
+++ b/livestudy/src/main/java/org/livestudy/service/RefreshTokenService.java
@@ -1,0 +1,58 @@
+package org.livestudy.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final StringRedisTemplate redis;
+    private final Duration ttl = Duration.ofDays(14);
+
+    public String issue(Long userId) {
+        String raw = randomUrlSafe(32);
+        String hash = sha256(raw);
+        redis.opsForValue().set(key(hash), String.valueOf(userId), ttl);
+        return raw;
+    }
+
+    public Long verifyAndConsume(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+        String k = key(sha256(raw));
+        String userId = redis.opsForValue().get(k);
+        if (userId == null) {
+            return null;
+        }
+        redis.delete(k);
+        return Long.valueOf(userId);
+    }
+
+    private static String key(String hash) {
+        return "refresh:" + hash;
+    }
+    private static String randomUrlSafe(int bytes) {
+        byte[] buf = new byte[bytes];
+        new SecureRandom().nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+
+    private static String sha256(String s) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(md.digest(s.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
# 이 PR을 통해 구현하려고 하는 기능
 이 PR은 JWT  토큰 만료시 refresh 토큰을 통해 새로운 토큰을 발급합니다.
 1. Jwt 토큰의 유효시간이 만료되면 401 오류를 반환하고, 그 응답을 통해 프런트엔드 쪽에서 /api/auth/refresh를 호출, refresh 토큰이 있을 시, 새로운 Jwt 토큰을 발급합니다.
 2. refresh 토큰은 14일의 유효시간이 있습니다.
 
# 변경된 사항
 1. RefreshTokenService.java 생성
    - issue 메소드를 통해 refresh:{hash}키로 userId 저장, raw 반환
 2. AuthController.java 수정
    - POST /api/auth/login에서 로그인 성공 시 refresh_token 쿠키
    - POST /api/auth/refresh에서 검증 성공 시 새로운 Access token 발급 및 refresh_token 갱신
 3. JwtAuthenticationFilter에서 ExpiredJwtException 캐치 시, 401 오류 응답