### PR TITLE
Fix/report message&repeatedreport

### DIFF
--- a/livestudy/src/main/java/org/livestudy/dto/ErrorResponse.java
+++ b/livestudy/src/main/java/org/livestudy/dto/ErrorResponse.java
@@ -9,6 +9,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ErrorResponse {
 
+    private String timestamp;
+    private int status;
+    private String error;
     private String errorCode;
     private String message;
+    private String path;
 }

--- a/livestudy/src/main/java/org/livestudy/service/report/ReportServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/report/ReportServiceImpl.java
@@ -70,7 +70,8 @@ public class ReportServiceImpl implements ReportService {
                 room.getId(), reported.getId(), distinctCnt, threshold);
 
         if (distinctCnt >= threshold) {
-            kickAndRestrict(room, reported, reportDto.getReason().toString());
+            String displayReason = reportDto.getReason().toString() + " 등의 사유";
+            kickAndRestrict(room, reported, displayReason);
         }
 
     }

--- a/livestudy/src/test/java/org/livestudy/UserServiceTest.java
+++ b/livestudy/src/test/java/org/livestudy/UserServiceTest.java
@@ -135,7 +135,7 @@ public class UserServiceTest {
         UserLoginResponse result = userService.login(request);
 
         // then
-        assertThat(result).isEqualTo(new UserLoginResponse(expectedToken));
+        assertThat(result).isEqualTo(new UserLoginResponse(expectedToken, user.getId()));
 
     }
 

--- a/livestudy/src/test/java/org/livestudy/service/report/ReportServiceIntegrationTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/report/ReportServiceIntegrationTest.java
@@ -12,7 +12,6 @@ import org.livestudy.dto.report.ReportDto;
 import org.livestudy.repository.StudyRoomRepository;
 import org.livestudy.repository.UserRepository;
 import org.livestudy.repository.report.ReportRepository;
-import org.livestudy.service.report.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;

--- a/livestudy/src/test/java/org/livestudy/service/report/ReportServiceIntegrationTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/report/ReportServiceIntegrationTest.java
@@ -61,4 +61,46 @@ class ReportServiceIntegrationTest {
         assertThat(saved.getReported().getId()).isEqualTo(reported.getId());
         assertThat(saved.getReason()).isEqualTo(ReportReason.ABUSE);
     }
+
+    @Test
+    @Rollback
+    void 중복신고_시_예외발생() {
+        // given
+        User reporter = userRepo.save(User.builder()
+                .email("tester1@example.com")
+                .password("123123")
+                .userStatus(UserStatus.NORMAL)
+                .socialProvider(SocialProvider.LOCAL)
+                .nickname("신고자")
+                .build());
+
+        User reported = userRepo.save(User.builder()
+                .email("tester2@example.com")
+                .password("123123")
+                .userStatus(UserStatus.NORMAL)
+                .socialProvider(SocialProvider.LOCAL)
+                .nickname("신고대상")
+                .build());
+
+        StudyRoom room = roomRepo.save(StudyRoom.builder()
+                .participantsNumber(3)
+                .status(StudyRoomStatus.OPEN)
+                .build());
+
+        ReportDto dto = ReportDto.builder()
+                .roomId(room.getId())
+                .reportedId(reported.getId())
+                .reason(ReportReason.ABUSE)
+                .description("욕설")
+                .build();
+
+        // 첫 신고
+        reportService.report(dto, reporter.getId());
+
+        // when & then - 중복 신고 시 CustomException(DUPLICATE_REPORT) 발생 확인
+        org.junit.jupiter.api.Assertions.assertThrows(
+                org.livestudy.exception.CustomException.class,
+                () -> reportService.report(dto, reporter.getId())
+        );
+    }
 }


### PR DESCRIPTION
fix/report-message&repeatedreport

- FE 요청사항입니다.

- 신고 기능 1번째는 정상적으로 접수되는데, 2번째로 동일한 사용자가 신고 진행 시, 500 Error가 아닌 409 Error가 발생하도록 요청이 들어와서 하기와 같이 변경 드립니다.

- 요청받은 양식
{
  "timestamp": "2025-08-28T05:56:38.314+00:00",
  "status": 409,
  "error": "Conflict",
  "code": "REPORT_DUPLICATE",
  "message": "이미 이 사용자를 신고하셨습니다.",
  "path": "/api/reports"
}

- ErrorResponse.java를 위의 양식 순서에 맞게 timestamp부터 path까지 있도록 수정 및 추가하였습니다.

- 퇴장 조치 시에, 가장 최근의 사유만 나타나도록 작성이 되어 있는 것으로 파악이 되어서, ~등의 사유로 다수의 사용자들에게 신고되어 퇴장하였습니다라는 메시지가 출력되게끔 변경하였습니다.