### PR TITLE
Fix/jeongsoo report3 redismessage

### DIFF
--- a/livestudy/src/main/java/org/livestudy/service/report/ReportService.java
+++ b/livestudy/src/main/java/org/livestudy/service/report/ReportService.java
@@ -1,10 +1,11 @@
 package org.livestudy.service.report;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.livestudy.dto.report.ReportDto;
 
 public interface ReportService {
 
     // 신고 저장
-    void report(ReportDto reportDto, Long reporterId);
+    void report(ReportDto reportDto, Long reporterId) throws JsonProcessingException;
 }
 

--- a/livestudy/src/main/java/org/livestudy/service/report/ReportServiceImpl.java
+++ b/livestudy/src/main/java/org/livestudy/service/report/ReportServiceImpl.java
@@ -1,5 +1,7 @@
 package org.livestudy.service.report;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.livestudy.domain.report.*;
@@ -25,7 +27,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Service
@@ -44,7 +48,7 @@ public class ReportServiceImpl implements ReportService {
 
     @Transactional
     @Override
-    public void report(ReportDto reportDto, Long reporterId) {
+    public void report(ReportDto reportDto, Long reporterId) throws JsonProcessingException {
         log.debug("[report] 호출됨, reportDto={}, reporterId={}", reportDto, reporterId);
 
         StudyRoom room = roomRepo.getReferenceById(reportDto.getRoomId());
@@ -91,7 +95,7 @@ public class ReportServiceImpl implements ReportService {
         return 3;
     }
 
-    private void kickAndRestrict(StudyRoom room, User target, String reason) {
+    private void kickAndRestrict(StudyRoom room, User target, String reason) throws JsonProcessingException {
         log.debug("[kickAndRestrict] 시작, roomId={}, targetId={}, reason={}", room.getId(), target.getId(), reason);
 
         // 1️⃣ 제한 메시지 발송
@@ -152,11 +156,20 @@ public class ReportServiceImpl implements ReportService {
         log.debug("[saveRestriction] 완료, targetId={}", target.getId());
     }
 
-    private void sendSystemKickMessage(Long roomId, Long targetId, String reason) {
-        String systemMessage = String.format("'%s' 사용자가 '%s' 사유로 신고를 당해 퇴장되었습니다.", targetId, reason);
-        redisTemplate.convertAndSend("systemMessage:" + roomId, systemMessage);
-        log.debug("[sendSystemKickMessage] Redis 발송 완료, roomId={}, targetId={}, message={}", roomId, targetId, systemMessage);
+    private void sendSystemKickMessage(Long roomId, Long targetId, String reason) throws JsonProcessingException {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("event", "USER_KICKED");
+        payload.put("roomId", roomId);
+        payload.put("targetId", targetId);
+        payload.put("reason", reason);
+        payload.put("timestamp", LocalDateTime.now().toString());
+
+        String jsonMessage = new ObjectMapper().writeValueAsString(payload);
+        redisTemplate.convertAndSend("systemMessage:" + roomId, jsonMessage);
+
+        log.debug("[sendSystemKickMessage] Redis 발송 완료, roomId={}, payload={}", roomId, jsonMessage);
     }
+
 
     private void disconnectKickUser(Long userId) {
         log.debug("[disconnectKickUser] 시작, userId={}", userId);

--- a/livestudy/src/test/java/org/livestudy/service/report/ReportServiceImplTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/report/ReportServiceImplTest.java
@@ -17,7 +17,6 @@ import org.livestudy.repository.UserRepository;
 import org.livestudy.repository.redis.RoomRedisRepository;
 import org.livestudy.repository.report.ReportRepository;
 import org.livestudy.repository.report.RestrictionRepository;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.session.SessionRegistry;
 
@@ -28,15 +27,15 @@ class ReportServiceImplTest {
 
     private ReportServiceImpl reportService;
 
-    private ReportRepository reportRepo = mock(ReportRepository.class);
-    private RestrictionRepository restrictionRepo = mock(RestrictionRepository.class);
-    private StudyRoomRepository roomRepo = mock(StudyRoomRepository.class);
-    private ChatRepository chatRepo = mock(ChatRepository.class);
-    private UserRepository userRepo = mock(UserRepository.class);
-    private StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
-    private SessionRegistry sessionRegistry = mock(SessionRegistry.class);
-    private ObjectMapper objectMapper = mock(ObjectMapper.class);
-    private RoomRedisRepository roomRedisRepository = mock(RoomRedisRepository.class);
+    private final ReportRepository reportRepo = mock(ReportRepository.class);
+    private final RestrictionRepository restrictionRepo = mock(RestrictionRepository.class);
+    private final StudyRoomRepository roomRepo = mock(StudyRoomRepository.class);
+    private final ChatRepository chatRepo = mock(ChatRepository.class);
+    private final UserRepository userRepo = mock(UserRepository.class);
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    private final SessionRegistry sessionRegistry = mock(SessionRegistry.class);
+    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+    private final RoomRedisRepository roomRedisRepository = mock(RoomRedisRepository.class);
 
     @BeforeEach
     void setUp() {

--- a/livestudy/src/test/java/org/livestudy/service/report/ReportServiceImplTest.java
+++ b/livestudy/src/test/java/org/livestudy/service/report/ReportServiceImplTest.java
@@ -1,5 +1,7 @@
 package org.livestudy.service.report;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.livestudy.domain.report.*;
@@ -12,6 +14,7 @@ import org.livestudy.exception.ErrorCode;
 import org.livestudy.repository.ChatRepository;
 import org.livestudy.repository.StudyRoomRepository;
 import org.livestudy.repository.UserRepository;
+import org.livestudy.repository.redis.RoomRedisRepository;
 import org.livestudy.repository.report.ReportRepository;
 import org.livestudy.repository.report.RestrictionRepository;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,17 +35,19 @@ class ReportServiceImplTest {
     private UserRepository userRepo = mock(UserRepository.class);
     private StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
     private SessionRegistry sessionRegistry = mock(SessionRegistry.class);
+    private ObjectMapper objectMapper = mock(ObjectMapper.class);
+    private RoomRedisRepository roomRedisRepository = mock(RoomRedisRepository.class);
 
     @BeforeEach
     void setUp() {
         reportService = new ReportServiceImpl(
                 reportRepo, restrictionRepo, roomRepo, chatRepo,
-                userRepo, redisTemplate, sessionRegistry
+                userRepo, redisTemplate, sessionRegistry, roomRedisRepository
         );
     }
 
     @Test
-    void report_정상_신고_처리_테스트() {
+    void report_정상_신고_처리_테스트() throws JsonProcessingException {
         // given
         Long reporterId = 1L;
         Long reportedId = 2L;


### PR DESCRIPTION
fix/jeongsoo-report3-redismessage

- redis message 서버로부터 수신할 때 String.format -> JSON 형태로 주어지도록 변경하였습니다.

- redis message Json형태는
{
  "event": "USER_KICKED",
  "roomId": 101,
  "targetId": 42,
  "reason": "욕설",
  "timestamp": "2025-09-05T15:23:45"
}

예시로 이렇게 따르게 됩니다.
참고 부탁 드리겠습니다.