### PR TITLE
Fix/jeongsoo websocket subscribe make

### DIFF
--- a/livestudy/src/main/java/org/livestudy/controller/report/ReportController.java
+++ b/livestudy/src/main/java/org/livestudy/controller/report/ReportController.java
@@ -1,5 +1,6 @@
 package org.livestudy.controller.report;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,7 +45,7 @@ public class ReportController {
             content = @Content(schema = @Schema(implementation = ReportRequest.class))
     )
     public ResponseEntity<Void> report(@Valid @RequestBody ReportRequest dto,
-                                       @AuthenticationPrincipal(expression = "id") Long userId) {
+                                       @AuthenticationPrincipal(expression = "id") Long userId) throws JsonProcessingException {
         reportService.report(dto.toCommand(), userId);
         return ResponseEntity.ok().build();
     }

--- a/livestudy/src/main/java/org/livestudy/websocket/controller/RoomWebSocketController.java
+++ b/livestudy/src/main/java/org/livestudy/websocket/controller/RoomWebSocketController.java
@@ -49,6 +49,10 @@ public class RoomWebSocketController {
 
         presence.join(assignedRoomId, sessionUser);
 
+        // 입장 이벤트 Broadcast
+        broker.convertAndSend("/topic/" + assignedRoomId + "/enter",
+                wrap(MsgType.join, join));
+
         return assignedRoomId;
     }
 
@@ -72,8 +76,11 @@ public class RoomWebSocketController {
             throw new CustomException(ErrorCode.USER_NOT_IN_ROOM);
         }
 
-
         presence.exit(roomId, sessionUser);
+
+        // 퇴장 이벤트 Broadcast
+        broker.convertAndSend("/topic/" + roomId + "/exit",
+                wrap(MsgType.exit, exit));
     }
 
     // 채팅


### PR DESCRIPTION
WebSocket Braodcast 경로를 집어넣었습니다.

* FE 요청사항 중에 Redis Message는 구독이 되었는데, 퇴장 이벤트에 대한 Message를 어디서 구독하냐에 대해서 살펴본 결과, 퇴장 이벤트에 대한 Message Broadcast가 없는 점이 발견되었습니다.

이런 문제사항에 대하여 하기와 같이 수정 드립니다.

- 기본 경로는 /topic/{roomId}/...이며, 
- 입장은 enter
- 퇴장은 exit
- 채팅은 enter 및 exit가 안 붙게 작성이 된 것을 그대로 유지합니다.